### PR TITLE
feat(01-01): docs/ folder structure + README restructure

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -11,11 +11,11 @@ See: .planning/PROJECT.md (updated 2026-03-19)
 
 Milestone: v1.1
 Phase: 01 of 04 (Information Architecture)
-Plan: —
-Status: Ready to plan
-Last activity: 2026-03-19 — Roadmap created for v1.1
+Plan: 01 of 03 in phase
+Status: In progress
+Last activity: 2026-03-19 — Completed 01-01-PLAN.md (docs/ skeleton + README navigation hub)
 
-Progress: [░░░░░░░░░░] 0%
+Progress: [█░░░░░░░░░] ~8% (1/~12 plans estimated)
 
 ## Performance Metrics
 
@@ -38,6 +38,12 @@ Progress: [░░░░░░░░░░] 0%
 
 Full decisions log in PROJECT.md Key Decisions table.
 
+| Plan | Decision | Rationale |
+|------|----------|-----------|
+| 01-01 | README condensed: removed "What is VIT?" H2 and "Built with GSD" section | Conceptual content belongs in docs/; README is a navigation hub |
+| 01-01 | docs/ split into user-guide/ and developer-guide/ | Clear separation of user-facing vs extension/developer content |
+| 01-01 | docs/developer-guide/README.md is placeholder only | Phase 04 owns full developer guide content |
+
 ### Pending Todos
 
 None.
@@ -48,8 +54,8 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-03-19
-Stopped at: Roadmap defined — v1.1 Phase 01 ready to plan
+Last session: 2026-03-19T08:42:29Z
+Stopped at: Completed 01-01-PLAN.md — docs/ skeleton and README nav hub done
 Resume file: None
 
 ## GitHub Issue Mapping

--- a/.planning/phases/v1.1/01-information-architecture/01-01-SUMMARY.md
+++ b/.planning/phases/v1.1/01-information-architecture/01-01-SUMMARY.md
@@ -1,0 +1,106 @@
+---
+phase: 01-information-architecture
+plan: 01
+subsystem: docs
+tags: [documentation, information-architecture, readme, navigation]
+
+# Dependency graph
+requires: []
+provides:
+  - docs/user-guide/README.md landing page with TOC linking to getting-started, core-concepts, glossary
+  - docs/developer-guide/README.md placeholder noting Phase 04 content scope
+  - Restructured README.md with Documentation navigation table linking to all docs/ pages
+affects:
+  - 01-02 (getting-started.md goes into docs/user-guide/ established here)
+  - 01-03 (core-concepts.md and glossary.md go into docs/user-guide/ established here)
+  - 04 (developer-guide content destination established here)
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "docs/ split: user-guide/ for user-facing content, developer-guide/ for extension docs"
+    - "README as navigation hub: short entry point linking out to docs/ rather than containing content"
+
+key-files:
+  created:
+    - docs/user-guide/README.md
+    - docs/developer-guide/README.md
+  modified:
+    - README.md
+
+key-decisions:
+  - "README condensed by removing 'What is VIT?' H2 (core loop folded into intro) and 'Built with GSD' section"
+  - "Documentation navigation table placed immediately after install block, before Commands reference"
+  - "docs/developer-guide/README.md is a placeholder only — full content scoped to Phase 04"
+
+patterns-established:
+  - "docs/ folder split: user-guide/ and developer-guide/ as top-level separation"
+  - "README.md as short navigation hub — conceptual content lives in docs/, not README"
+
+# Metrics
+duration: 2min
+completed: 2026-03-19
+---
+
+# Phase 01 Plan 01: Information Architecture — docs/ skeleton and README navigation hub
+
+**docs/ folder skeleton with user-guide and developer-guide directories, README.md restructured from 200 to 162 lines as a navigation hub linking to 5 docs/ pages**
+
+## Performance
+
+- **Duration:** 2 min
+- **Started:** 2026-03-19T08:40:22Z
+- **Completed:** 2026-03-19T08:42:29Z
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+
+- Created `docs/user-guide/README.md` with table of contents linking to getting-started, core-concepts, and glossary pages that Plans 02 and 03 will populate
+- Created `docs/developer-guide/README.md` as a placeholder explicitly naming Phase 04 as its content source
+- Restructured `README.md` from 200 to 162 lines: removed "What is VIT?" H2 (core loop folded into intro), removed "Built with GSD" section, added Documentation navigation table with 5 links to docs/ pages
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create docs/ folder structure with index READMEs** - `f383c34` (docs)
+2. **Task 2: Restructure root README.md as navigation hub** - `e0ad2e6` (docs)
+
+**Plan metadata:** (docs: complete plan — committed after this summary)
+
+## Files Created/Modified
+
+- `docs/user-guide/README.md` — User guide landing page with TOC (getting-started, core-concepts, glossary)
+- `docs/developer-guide/README.md` — Developer guide placeholder pointing to Phase 04
+- `README.md` — Restructured as navigation hub: 200 → 162 lines, Documentation section added, conceptual sections removed
+
+## Decisions Made
+
+- README condensed by removing "What is VIT?" H2 (core loop folded into intro paragraph) and "Built with GSD" section — these are noise at the entry point; conceptual content belongs in docs/
+- Documentation navigation table placed immediately after install block, before Commands reference — users who want to learn navigate there before diving into the command table
+- `docs/developer-guide/README.md` is a placeholder only — scoping full content to Phase 04 keeps this plan focused on structure without fabricating content
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- `docs/user-guide/` directory exists and has a landing README — Plans 02 and 03 can slot `getting-started.md`, `core-concepts.md`, and `glossary.md` into it directly
+- `docs/developer-guide/` exists with placeholder — Phase 04 has a clear destination
+- README.md navigation table has links to all 5 docs/ pages; they will resolve once Plans 02 and 03 create the target files
+- No blockers for Plans 02 or 03
+
+---
+*Phase: 01-information-architecture*
+*Completed: 2026-03-19*

--- a/README.md
+++ b/README.md
@@ -2,52 +2,11 @@
 
 **Phase-based project execution framework for Claude Code — with GitHub integration.**
 
-VIT gives Claude Code a structured, repeatable way to plan and execute software projects: one phase at a time, with atomic commits, parallel agents, CI feedback on GitHub issues, and persistent state that survives context resets.
-
-```bash
-npx vit-claude
-```
-
----
-
-## What is VIT?
-
-VIT is a Claude Code workflow framework. It installs as slash commands, specialist agents, and session hooks directly into your `.claude/` directory.
-
-The core loop is:
+VIT gives Claude Code a structured, repeatable way to plan and execute software projects: one phase at a time, with atomic commits, parallel agents, CI feedback on GitHub issues, and persistent state that survives context resets. The core loop is:
 
 ```
 /vit:new-project  →  /vit:plan-phase  →  /vit:execute-phase  →  /vit:verify-work
 ```
-
-Each phase produces atomic commits on a feature branch, updates a `STATE.md` tracker, and optionally posts CI results back to the linked GitHub issue. When context fills up, `/vit:pause-work` creates a handoff document so the next session resumes exactly where you left off.
-
----
-
-## Built with GSD
-
-VIT was developed using [GSD (Get Shit Done)](https://github.com/LeVarez/gsd-cc), the framework that preceded it. GSD's planning and execution methodology was used to build VIT itself — including the roadmap, phase plans, and every execution wave. VIT is GSD's successor with a stronger emphasis on GitHub integration, multi-milestone state management, and verification agents.
-
----
-
-## GitHub Integration — the key extension
-
-VIT's standout feature is its closed-loop GitHub integration. When you push a feature branch, `phase-ci.yml` automatically:
-
-1. Runs your phase test suite (`tests/phases/`)
-2. Looks up the linked GitHub issue from `STATE.md`
-3. Posts a CI result comment directly to that issue:
-   - `✅ CI Passed — N/M tests passed. Ready for human review.`
-   - `❌ CI Failed — N failing tests. Fix before verify.`
-   - `🔄 No tests yet — waiting for test generation.`
-
-The `/vit:review-feedback` command reads developer feedback comments from the issue and implements changes as fix commits — creating a full review loop without leaving the terminal.
-
-**Requires:** `GITHUB_TOKEN` in your repo secrets (automatically available in GitHub Actions).
-
----
-
-## Install
 
 ```bash
 npx vit-claude
@@ -65,14 +24,15 @@ This copies all framework files into your project's `.claude/` directory and opt
 
 ---
 
-## Getting started
+## Documentation
 
-```
-/vit:new-project        — Deep context gathering, produces PROJECT.md + roadmap
-/vit:plan-phase 1       — Research + plan Phase 1, produces PLAN.md
-/vit:execute-phase 1    — Execute the plan with parallel agents + atomic commits
-/vit:verify-work 1      — Conversational UAT against phase success criteria
-```
+| Section | Description |
+|---------|-------------|
+| [Getting Started](docs/user-guide/getting-started.md) | Install VIT and run your first phase |
+| [Core Concepts](docs/user-guide/core-concepts.md) | The milestone → phase → plan → task mental model |
+| [Glossary](docs/user-guide/glossary.md) | Definitions for all VIT-specific terms |
+| [User Guide](docs/user-guide/README.md) | All user-facing documentation |
+| [Developer Guide](docs/developer-guide/README.md) | Extending VIT with custom agents and commands |
 
 ---
 
@@ -156,6 +116,8 @@ Run /vit:verify-work 1 to complete manual UAT.
 ```
 
 **Test location:** `tests/phases/` — VIT's `vit-test-writer` agent generates these automatically after phase execution. If no tests exist yet, the workflow posts a "waiting" comment instead of failing.
+
+**Requires:** `GITHUB_TOKEN` in your repo secrets (automatically available in GitHub Actions).
 
 ---
 

--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -1,0 +1,5 @@
+# Developer Guide
+
+This section will cover extending VIT with custom agents, slash commands, and templates. It documents the framework's three-layer architecture (command → agent → state-store) and provides step-by-step tutorials for building your own components.
+
+> Content is being written as part of v1.1 Phase 04. See the [User Guide](../user-guide/README.md) for current documentation.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,15 @@
+# User Guide
+
+This section covers everything you need to use VIT: getting started with installation, the core mental model, a glossary of VIT-specific terms, and (in later phases) command and agent reference pages.
+
+## Contents
+
+| Page | Description |
+|------|-------------|
+| [Getting Started](getting-started.md) | Install VIT and run your first phase |
+| [Core Concepts](core-concepts.md) | The milestone → phase → plan → task mental model |
+| [Glossary](glossary.md) | Definitions for all VIT-specific terms |
+
+## Coming in later phases
+
+Phase 02 will add a full command reference (all 29 slash commands with options and examples) and an agent reference (all 16 specialist agents with their roles and trigger conditions).


### PR DESCRIPTION
Closes #40
Part of #36

## What this plan builds
docs/ folder skeleton with user-guide/ and developer-guide/ index pages, plus README.md restructured as navigation hub.