### PR TITLE
feat(phase-01): readme rewrite with ascii art branding

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -7,19 +7,19 @@
 
 ### README
 
-- [ ] **README-01**: ASCII art hero banner using box-drawing characters consistent with ui-brand.md, renders correctly on GitHub and in terminal
-- [ ] **README-02**: "What is VIT?" section with core loop diagram (new-project → plan-phase → execute-phase → verify-work)
-- [ ] **README-03**: Visual install section with `npx vit-claude` command, listing installed components (agents, commands, hooks, workflows, CI)
-- [ ] **README-04**: Quick Start numbered walkthrough from zero to first phase complete
-- [ ] **README-05**: Complete commands reference — all 31 commands organized into 11 groups with ASCII section headers, each with name, description, usage example, and produced artifacts
-- [ ] **README-06**: Complete agents reference — all 16 agents in table with spawner command, role description, and output
-- [ ] **README-07**: Settings reference — all config.json keys with defaults and descriptions, including model profile matrix table
-- [ ] **README-08**: GitHub CI Integration section explaining phase-ci.yml, branch→issue linking, issue comments, and review-feedback loop
-- [ ] **README-09**: Architecture diagram in ASCII art showing plan-phase, execute-phase, and verify-work agent pipelines with state management files
-- [ ] **README-10**: Project structure — ASCII tree of .planning/ and .claude/ directories
-- [ ] **README-11**: Common Workflows section with 6 recipes (greenfield, brownfield, resume, urgent work, team collab, debugging)
-- [ ] **README-12**: ASCII art style consistency throughout — section headers with ━━━, dividers with ───, approved status symbols only, no random emoji
-- [ ] **README-13**: Footer with license, Discord link, GitHub issues link, and docs site link
+- [x] **README-01**: ASCII art hero banner using box-drawing characters consistent with ui-brand.md, renders correctly on GitHub and in terminal
+- [x] **README-02**: "What is VIT?" section with core loop diagram (new-project → plan-phase → execute-phase → verify-work)
+- [x] **README-03**: Visual install section with `npx vit-claude` command, listing installed components (agents, commands, hooks, workflows, CI)
+- [x] **README-04**: Quick Start numbered walkthrough from zero to first phase complete
+- [x] **README-05**: Complete commands reference — all 31 commands organized into 11 groups with ASCII section headers, each with name, description, usage example, and produced artifacts
+- [x] **README-06**: Complete agents reference — all 16 agents in table with spawner command, role description, and output
+- [x] **README-07**: Settings reference — all config.json keys with defaults and descriptions, including model profile matrix table
+- [x] **README-08**: GitHub CI Integration section explaining phase-ci.yml, branch→issue linking, issue comments, and review-feedback loop
+- [x] **README-09**: Architecture diagram in ASCII art showing plan-phase, execute-phase, and verify-work agent pipelines with state management files
+- [x] **README-10**: Project structure — ASCII tree of .planning/ and .claude/ directories
+- [x] **README-11**: Common Workflows section with 6 recipes (greenfield, brownfield, resume, urgent work, team collab, debugging)
+- [x] **README-12**: ASCII art style consistency throughout — section headers with ━━━, dividers with ───, approved status symbols only, no random emoji
+- [x] **README-13**: Footer with license, Discord link, GitHub issues link, and docs site link
 
 ### Docs Site
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -33,13 +33,14 @@ Full details: `.planning/milestones/v1.0-ROADMAP.md`
   3. All 16 agents are documented in a table with spawner command, role description, and output
   4. All config.json keys are documented with defaults, descriptions, and the model profile matrix table
   5. Visual style is consistent throughout: section headers use ━━━, dividers use ───, no unapproved emoji, matching ui-brand.md conventions
-**Plans:** 4 plans
+**Plans:** 5 plans
 
 Plans:
 - [ ] 01-01-PLAN.md — README skeleton with hero banner, intro sections, and placeholders for reference tables
 - [ ] 01-02-PLAN.md — Commands reference: all 31 commands in 11 groups with descriptions, usage, and artifacts
 - [ ] 01-03-PLAN.md — Agents reference (16 agents) and settings reference (config keys + model profile matrix)
 - [ ] 01-04-PLAN.md — Style consistency pass and human visual verification
+- [ ] 01-05-PLAN.md — Gap closure: replace plain text VIT with figlet ASCII art and diff-block color
 
 #### Phase 02: GitHub Pages Technical Documentation Site
 
@@ -63,5 +64,5 @@ Plans:
 | 1. PR Lifecycle Foundation | v1.0 | 2/2 | Complete ✓ | 2026-03-18 |
 | 2. AI PR Reviewer | v1.0 | 2/2 | Complete ✓ | 2026-03-18 |
 | 3. Documentation & Changelog Agents | v1.0 | 4/4 | Complete ✓ | 2026-03-18 |
-| 01. README Rewrite with ASCII Art Branding | v1.1 | 0/4 | Not started | - |
+| 01. README Rewrite with ASCII Art Branding | v1.1 | 0/5 | In progress | - |
 | 02. GitHub Pages Technical Documentation Site | v1.1 | 0/? | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -33,10 +33,13 @@ Full details: `.planning/milestones/v1.0-ROADMAP.md`
   3. All 16 agents are documented in a table with spawner command, role description, and output
   4. All config.json keys are documented with defaults, descriptions, and the model profile matrix table
   5. Visual style is consistent throughout: section headers use ━━━, dividers use ───, no unapproved emoji, matching ui-brand.md conventions
-**Plans:** TBD
+**Plans:** 4 plans
 
 Plans:
-- [ ] 01-01: TBD
+- [ ] 01-01-PLAN.md — README skeleton with hero banner, intro sections, and placeholders for reference tables
+- [ ] 01-02-PLAN.md — Commands reference: all 31 commands in 11 groups with descriptions, usage, and artifacts
+- [ ] 01-03-PLAN.md — Agents reference (16 agents) and settings reference (config keys + model profile matrix)
+- [ ] 01-04-PLAN.md — Style consistency pass and human visual verification
 
 #### Phase 02: GitHub Pages Technical Documentation Site
 
@@ -60,5 +63,5 @@ Plans:
 | 1. PR Lifecycle Foundation | v1.0 | 2/2 | Complete ✓ | 2026-03-18 |
 | 2. AI PR Reviewer | v1.0 | 2/2 | Complete ✓ | 2026-03-18 |
 | 3. Documentation & Changelog Agents | v1.0 | 4/4 | Complete ✓ | 2026-03-18 |
-| 01. README Rewrite with ASCII Art Branding | v1.1 | 0/? | Not started | - |
+| 01. README Rewrite with ASCII Art Branding | v1.1 | 0/4 | Not started | - |
 | 02. GitHub Pages Technical Documentation Site | v1.1 | 0/? | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -36,11 +36,11 @@ Full details: `.planning/milestones/v1.0-ROADMAP.md`
 **Plans:** 5 plans
 
 Plans:
-- [ ] 01-01-PLAN.md — README skeleton with hero banner, intro sections, and placeholders for reference tables
-- [ ] 01-02-PLAN.md — Commands reference: all 31 commands in 11 groups with descriptions, usage, and artifacts
-- [ ] 01-03-PLAN.md — Agents reference (16 agents) and settings reference (config keys + model profile matrix)
-- [ ] 01-04-PLAN.md — Style consistency pass and human visual verification
-- [ ] 01-05-PLAN.md — Gap closure: replace plain text VIT with figlet ASCII art and diff-block color
+- [x] 01-01-PLAN.md — README skeleton with hero banner, intro sections, and placeholders for reference tables
+- [x] 01-02-PLAN.md — Commands reference: all 31 commands in 11 groups with descriptions, usage, and artifacts
+- [x] 01-03-PLAN.md — Agents reference (16 agents) and settings reference (config keys + model profile matrix)
+- [x] 01-04-PLAN.md — Style consistency pass and human visual verification
+- [x] 01-05-PLAN.md — Gap closure: replace plain text VIT with figlet ASCII art and diff-block color
 
 #### Phase 02: GitHub Pages Technical Documentation Site
 
@@ -64,5 +64,5 @@ Plans:
 | 1. PR Lifecycle Foundation | v1.0 | 2/2 | Complete ✓ | 2026-03-18 |
 | 2. AI PR Reviewer | v1.0 | 2/2 | Complete ✓ | 2026-03-18 |
 | 3. Documentation & Changelog Agents | v1.0 | 4/4 | Complete ✓ | 2026-03-18 |
-| 01. README Rewrite with ASCII Art Branding | v1.1 | 0/5 | In progress | - |
+| 01. README Rewrite with ASCII Art Branding | v1.1 | 5/5 | Complete ✓ | 2026-03-19 |
 | 02. GitHub Pages Technical Documentation Site | v1.1 | 0/? | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -12,8 +12,8 @@ See: .planning/PROJECT.md (updated 2026-03-19)
 Milestone: v1.1
 Phase: 01 of 02 (README Rewrite with ASCII Art Branding)
 Plan: —
-Status: Ready to plan
-Last activity: 2026-03-19 — Roadmap created for v1.1
+Status: Planned (4 plans in 4 waves)
+Last activity: 2026-03-19 — Phase 01 planned
 
 Progress: [░░░░░░░░░░] 0%
 
@@ -56,5 +56,5 @@ Resume file: None
 
 | Phase | Feature Issue | Branch | PR | Assigned | Sub-issues | Plan Branches |
 |-------|---------------|--------|----|----------|------------|---------------|
-| v1.1/01 | #47 | feature/v1.1-01-readme-rewrite | — | — | — | — |
+| v1.1/01 | #47 | feature/v1.1-01-readme-rewrite | — | — | #49, #50, #51, #52 | feature/v1.1-01-01, feature/v1.1-01-02, feature/v1.1-01-03, feature/v1.1-01-04 |
 | v1.1/02 | #48 | feature/v1.1-02-docs-site | — | — | — | — |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -11,11 +11,11 @@ See: .planning/PROJECT.md (updated 2026-03-19)
 
 Milestone: v1.1
 Phase: 01 of 02 (README Rewrite with ASCII Art Branding)
-Plan: 2 of 4 complete
+Plan: 3 of 4 complete
 Status: In progress
-Last activity: 2026-03-19 — Completed v1.1-01-02-PLAN.md (Commands Reference)
+Last activity: 2026-03-19 — Completed v1.1-01-03-PLAN.md (Agents Reference + Settings Reference)
 
-Progress: [██░░░░░░░░] 20%
+Progress: [███░░░░░░░] 30%
 
 ## Performance Metrics
 
@@ -50,6 +50,12 @@ Full decisions log in PROJECT.md Key Decisions table.
 - Descriptions taken verbatim from description: frontmatter field of each command file
 - /vit:set-profile included as /vit:set-profile even though frontmatter omits vit: prefix
 
+**v1.1/01 Plan 03 decisions:**
+- Agent descriptions sourced directly from frontmatter of each agent file, not from memory
+- vit-verifier and vit-integration-checker spawn source identified via command files (execute-phase, audit-milestone) since their own descriptions omit "Spawned by"
+- Model profile matrix matches model-profiles.md exactly (11 agents x 3 profiles)
+- Sample config.json shows all 11 keys at documented defaults
+
 ### Pending Todos
 
 None.
@@ -61,7 +67,7 @@ None.
 ## Session Continuity
 
 Last session: 2026-03-19
-Stopped at: Completed v1.1/01 Plan 02 — Commands Reference (31 commands, 11 groups) added to README.md
+Stopped at: Completed v1.1/01 Plan 03 — Agents Reference (16 agents) and Settings Reference (11 config keys + model matrix) added to README.md
 Resume file: None
 
 ## GitHub Issue Mapping

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -83,5 +83,5 @@ Resume file: None
 
 | Phase | Feature Issue | Branch | PR | Assigned | Sub-issues | Plan Branches |
 |-------|---------------|--------|----|----------|------------|---------------|
-| v1.1/01 | #47 | feature/v1.1-01-readme-rewrite | pr#53 | — | #49, #50, #51, #52 | feature/v1.1-01-01, feature/v1.1-01-02, feature/v1.1-01-03, feature/v1.1-01-04 |
+| v1.1/01 | #47 | feature/v1.1-01-readme-rewrite | pr#53(ready) | — | #49, #50, #51, #52 | feature/v1.1-01-01, feature/v1.1-01-02, feature/v1.1-01-03, feature/v1.1-01-04 |
 | v1.1/02 | #48 | feature/v1.1-02-docs-site | — | — | — | — |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -11,11 +11,11 @@ See: .planning/PROJECT.md (updated 2026-03-19)
 
 Milestone: v1.1
 Phase: 01 of 02 (README Rewrite with ASCII Art Branding)
-Plan: 1 of 4 complete
+Plan: 2 of 4 complete
 Status: In progress
-Last activity: 2026-03-19 — Completed v1.1-01-01-PLAN.md (README skeleton)
+Last activity: 2026-03-19 — Completed v1.1-01-02-PLAN.md (Commands Reference)
 
-Progress: [█░░░░░░░░░] 10%
+Progress: [██░░░░░░░░] 20%
 
 ## Performance Metrics
 
@@ -44,6 +44,12 @@ Full decisions log in PROJECT.md Key Decisions table.
 - Section dividers: stage banner pattern (━━━) inside fenced code blocks above each ## heading
 - Footer Discord/docs URLs: placeholder values (discord.gg/vit-claude, vit-claude.dev) — not found in repo
 
+**v1.1/01 Plan 02 decisions:**
+- Compact table format (not per-command headings) for 31-command reference — fits density requirement
+- ASCII dividers use ─── style inside fenced code blocks per group, consistent with Plan 01 section header pattern
+- Descriptions taken verbatim from description: frontmatter field of each command file
+- /vit:set-profile included as /vit:set-profile even though frontmatter omits vit: prefix
+
 ### Pending Todos
 
 None.
@@ -55,7 +61,7 @@ None.
 ## Session Continuity
 
 Last session: 2026-03-19
-Stopped at: Completed v1.1/01 Plan 01 — README skeleton with 3 placeholder markers
+Stopped at: Completed v1.1/01 Plan 02 — Commands Reference (31 commands, 11 groups) added to README.md
 Resume file: None
 
 ## GitHub Issue Mapping

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -11,11 +11,11 @@ See: .planning/PROJECT.md (updated 2026-03-19)
 
 Milestone: v1.1
 Phase: 01 of 02 (README Rewrite with ASCII Art Branding)
-Plan: —
-Status: Planned (4 plans in 4 waves)
-Last activity: 2026-03-19 — Phase 01 planned
+Plan: 1 of 4 complete
+Status: In progress
+Last activity: 2026-03-19 — Completed v1.1-01-01-PLAN.md (README skeleton)
 
-Progress: [░░░░░░░░░░] 0%
+Progress: [█░░░░░░░░░] 10%
 
 ## Performance Metrics
 
@@ -38,6 +38,12 @@ Progress: [░░░░░░░░░░] 0%
 
 Full decisions log in PROJECT.md Key Decisions table.
 
+**v1.1/01 Plan 01 decisions:**
+- Use HTML comment markers (`<!-- PLACEHOLDER -->`) in README so sections render cleanly if downstream plans don't fill them
+- Hero banner: 62-char checkpoint box width (╔══╗) matching ui-brand.md checkpoint box dimension
+- Section dividers: stage banner pattern (━━━) inside fenced code blocks above each ## heading
+- Footer Discord/docs URLs: placeholder values (discord.gg/vit-claude, vit-claude.dev) — not found in repo
+
 ### Pending Todos
 
 None.
@@ -49,7 +55,7 @@ None.
 ## Session Continuity
 
 Last session: 2026-03-19
-Stopped at: Roadmap created — v1.1 Phase 01 ready to plan
+Stopped at: Completed v1.1/01 Plan 01 — README skeleton with 3 placeholder markers
 Resume file: None
 
 ## GitHub Issue Mapping

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -11,11 +11,11 @@ See: .planning/PROJECT.md (updated 2026-03-19)
 
 Milestone: v1.1
 Phase: 01 of 02 (README Rewrite with ASCII Art Branding)
-Plan: 3 of 4 complete
-Status: In progress
-Last activity: 2026-03-19 — Completed v1.1-01-03-PLAN.md (Agents Reference + Settings Reference)
+Plan: 4 of 4 — awaiting human verification checkpoint (Task 2)
+Status: In progress — checkpoint
+Last activity: 2026-03-19 — Completed v1.1-01-04 Task 1 (style consistency pass, no changes needed)
 
-Progress: [███░░░░░░░] 30%
+Progress: [████░░░░░░] 40%
 
 ## Performance Metrics
 
@@ -56,6 +56,10 @@ Full decisions log in PROJECT.md Key Decisions table.
 - Model profile matrix matches model-profiles.md exactly (11 agents x 3 profiles)
 - Sample config.json shows all 11 keys at documented defaults
 
+**v1.1/01 Plan 04 decisions:**
+- Emoji ✅ ❌ 🔄 inside fenced CI example code blocks are acceptable — they represent literal GitHub comment output, not decorative document emoji
+- No README changes needed — all prior plans produced a consistent, clean document
+
 ### Pending Todos
 
 None.
@@ -67,7 +71,7 @@ None.
 ## Session Continuity
 
 Last session: 2026-03-19
-Stopped at: Completed v1.1/01 Plan 03 — Agents Reference (16 agents) and Settings Reference (11 config keys + model matrix) added to README.md
+Stopped at: v1.1/01 Plan 04 — Task 1 complete (style pass, no changes). Awaiting Task 2 human verification checkpoint.
 Resume file: None
 
 ## GitHub Issue Mapping

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -10,12 +10,12 @@ See: .planning/PROJECT.md (updated 2026-03-19)
 ## Current Position
 
 Milestone: v1.1
-Phase: 01 of 02 (README Rewrite with ASCII Art Branding)
-Plan: 4 of 4 — awaiting human verification checkpoint (Task 2)
-Status: In progress — checkpoint
-Last activity: 2026-03-19 — Completed v1.1-01-04 Task 1 (style consistency pass, no changes needed)
+Phase: 01 of 02 (README Rewrite with ASCII Art Branding) — COMPLETE
+Plan: 5 of 5 (gap closure) — complete
+Status: Phase complete — ready to merge or advance to Phase 02
+Last activity: 2026-03-19 — Completed v1.1-01-05 (ASCII art hero banner gap closure)
 
-Progress: [████░░░░░░] 40%
+Progress: [█████░░░░░] 50%
 
 ## Performance Metrics
 
@@ -60,6 +60,11 @@ Full decisions log in PROJECT.md Key Decisions table.
 - Emoji ✅ ❌ 🔄 inside fenced CI example code blocks are acceptable — they represent literal GitHub comment output, not decorative document emoji
 - No README changes needed — all prior plans produced a consistent, clean document
 
+**v1.1/01 Plan 05 decisions (gap closure):**
+- diff code block (not HTML spans/font tags) used for hero banner color — broadest GitHub compatibility
+- Subtitle lines kept without + prefix for neutral/white color, contrasting the green ASCII art
+- Old box-drawing frame (╔══╗) removed — diff block provides sufficient visual framing
+
 ### Pending Todos
 
 None.
@@ -71,12 +76,12 @@ None.
 ## Session Continuity
 
 Last session: 2026-03-19
-Stopped at: v1.1/01 Plan 04 — Task 1 complete (style pass, no changes). Awaiting Task 2 human verification checkpoint.
+Stopped at: v1.1/01 Plan 05 — complete. Phase 01 fully done.
 Resume file: None
 
 ## GitHub Issue Mapping
 
 | Phase | Feature Issue | Branch | PR | Assigned | Sub-issues | Plan Branches |
 |-------|---------------|--------|----|----------|------------|---------------|
-| v1.1/01 | #47 | feature/v1.1-01-readme-rewrite | — | — | #49, #50, #51, #52 | feature/v1.1-01-01, feature/v1.1-01-02, feature/v1.1-01-03, feature/v1.1-01-04 |
+| v1.1/01 | #47 | feature/v1.1-01-readme-rewrite | pr#53 | — | #49, #50, #51, #52 | feature/v1.1-01-01, feature/v1.1-01-02, feature/v1.1-01-03, feature/v1.1-01-04 |
 | v1.1/02 | #48 | feature/v1.1-02-docs-site | — | — | — | — |

--- a/.planning/phases/v1.1/01-readme-rewrite/01-01-PLAN.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-01-PLAN.md
@@ -1,0 +1,203 @@
+---
+phase: 01-readme-rewrite
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified: [README.md]
+autonomous: true
+assigned_to: ""
+execute_by: claude
+
+must_haves:
+  truths:
+    - "README has an ASCII art hero banner inside a fenced code block using box-drawing characters"
+    - "README has a What is VIT section with the core loop diagram (new-project -> plan-phase -> execute-phase -> verify-work)"
+    - "README has an Install section showing npx vit-claude with component listing"
+    - "README has a Quick Start numbered walkthrough"
+    - "README has a GitHub CI Integration section explaining phase-ci.yml"
+    - "README has an ASCII architecture diagram showing plan-phase, execute-phase, verify-work pipelines"
+    - "README has a project structure ASCII tree for .planning/ and .claude/"
+    - "README has a Common Workflows section with 6 recipes"
+    - "README has a footer with license, Discord, GitHub issues, and docs site links"
+    - "Commands Reference section exists with a COMMANDS_PLACEHOLDER marker for Plan 02 to fill"
+    - "Agents Reference section exists with an AGENTS_PLACEHOLDER marker for Plan 03 to fill"
+    - "Settings Reference section exists with a SETTINGS_PLACEHOLDER marker for Plan 03 to fill"
+  artifacts:
+    - path: "README.md"
+      provides: "Complete README structure with all sections except commands/agents/settings tables"
+      min_lines: 200
+  key_links:
+    - from: "README.md"
+      to: ".claude/vit/references/ui-brand.md"
+      via: "Visual style consistency"
+      pattern: "fenced code block.*box-drawing"
+---
+
+<objective>
+Create the full README.md structure with all sections that can be written from existing context, leaving placeholder markers for the three heavy reference tables (commands, agents, settings) that Plans 02 and 03 will fill in.
+
+Purpose: Establish the complete document skeleton and write 10 of 13 requirements (README-01, 02, 03, 04, 08, 09, 10, 11, 12 partially, 13) so that subsequent plans only need to fill in reference tables.
+
+Output: README.md with complete content except three PLACEHOLDER markers.
+</objective>
+
+<execution_context>
+@./.claude/vit/workflows/execute-plan.md
+@./.claude/vit/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/v1.1/01-readme-rewrite/01-RESEARCH.md
+@.claude/vit/references/ui-brand.md
+@.planning/codebase/STRUCTURE.md
+@.github/workflows/phase-ci.yml
+@README.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create README.md with hero banner, intro sections, and full skeleton</name>
+  <files>README.md</files>
+  <action>
+Replace the existing README.md with a complete new version. The document must follow this exact section order (derived from 01-RESEARCH.md):
+
+**1. Hero Banner (README-01):**
+- Create an ASCII art banner using box-drawing characters (double-line: ╔ ═ ╗ ║ ╚ ╝)
+- MUST be inside a fenced code block (triple backticks) for GitHub monospace rendering
+- Include "VIT" prominently and a tagline like "Phase-based project execution for Claude Code"
+- Use 62-character width consistent with ui-brand.md checkpoint box width
+- Below the code block, add a one-line description in regular Markdown
+
+**2. What is VIT? (README-02):**
+- Explain VIT as a Claude Code workflow framework with slash commands, agents, and hooks
+- Include the core loop diagram in a fenced code block:
+  ```
+  /vit:new-project  ->  /vit:plan-phase  ->  /vit:execute-phase  ->  /vit:verify-work
+  ```
+- Mention: atomic commits, parallel agents, CI feedback on GitHub issues, state that survives context resets
+
+**3. Install (README-03):**
+- Show `npx vit-claude` in a bash code block
+- List what gets installed with counts:
+  - 16 specialist agents (.claude/agents/vit-*.md)
+  - 31 slash commands (.claude/commands/vit/*.md)
+  - 2 session hooks (vit-check-update.cjs, vit-statusline.js)
+  - Core references, templates, workflows (.claude/vit/)
+  - GitHub CI workflow (.github/workflows/phase-ci.yml) — opt-in
+  - Hook registrations in .claude/settings.json
+
+**4. Quick Start (README-04):**
+- Numbered steps 1-4 showing the core loop commands
+- Each step: command in code block + one-line description of what happens
+- Step 1: /vit:new-project (produces PROJECT.md + roadmap)
+- Step 2: /vit:plan-phase 1 (produces PLAN.md)
+- Step 3: /vit:execute-phase 1 (parallel agents + atomic commits)
+- Step 4: /vit:verify-work 1 (conversational UAT)
+
+**5. Commands Reference (README-05) — PLACEHOLDER:**
+- Write the section heading with an ASCII section header in a fenced code block using the stage banner pattern from ui-brand.md:
+  ```
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   COMMANDS REFERENCE
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ```
+- Add intro text: "31 commands organized into 11 groups. Each command is a slash command invoked as `/vit:<name>`."
+- Insert the marker: `<!-- COMMANDS_PLACEHOLDER -->`
+
+**6. Agents Reference (README-06) — PLACEHOLDER:**
+- Write section heading with ASCII section header (same pattern as commands)
+- Add intro text: "VIT spawns 16 specialist agents automatically — you don't invoke them directly."
+- Insert the marker: `<!-- AGENTS_PLACEHOLDER -->`
+
+**7. Settings Reference (README-07) — PLACEHOLDER:**
+- Write section heading with ASCII section header
+- Add intro text about .planning/config.json
+- Insert the marker: `<!-- SETTINGS_PLACEHOLDER -->`
+
+**8. GitHub CI Integration (README-08):**
+- Explain phase-ci.yml: triggers on pushes to feature/**, milestone/**, quick/** branches
+- How it finds the issue: branch name pattern -> STATE.md lookup
+- What it posts: show the CI comment format (pass/fail/waiting)
+- Test location: tests/phases/ generated by vit-test-writer
+- Mention /vit:review-feedback for the feedback loop
+
+**9. Architecture (README-09):**
+- ASCII art diagram in a fenced code block showing all three pipelines:
+  - /vit:plan-phase -> researcher, planner, plan-checker
+  - /vit:execute-phase -> draft PR, waves, integration-checker, test-writer, doc-updater, push
+  - /vit:verify-work -> verifier, PR ready, PR reviewer
+- Below diagram: mention state files (STATE.md, MILESTONE.md, per-phase PLAN.md)
+
+**10. Project Structure (README-10):**
+- Two ASCII trees in fenced code blocks:
+  - .planning/ directory structure (from STRUCTURE.md)
+  - .claude/ directory structure (from STRUCTURE.md)
+
+**11. Common Workflows (README-11):**
+- 6 recipes, each with a heading, brief description, and the key commands:
+  1. Greenfield — /vit:new-project from scratch
+  2. Brownfield — /vit:new-project on existing codebase + /vit:map-codebase
+  3. Resume — /vit:resume-work after context reset
+  4. Urgent work — /vit:insert-phase for hotfixes
+  5. Team collaboration — team config + /vit:assign-phase + /vit:team-status
+  6. Debugging — /vit:debug for systematic investigation
+
+**12. Footer (README-13):**
+- License: MIT
+- Discord: placeholder URL `https://discord.gg/vit-claude` (flagged as TBD in research)
+- GitHub issues: link to repo issues
+- Docs site: placeholder URL `https://vit-claude.dev` (Phase 02 will create this)
+
+**Style rules (README-12) — apply throughout:**
+- ALL multi-line ASCII art in fenced code blocks
+- Section headers between major sections use the ━━━ banner pattern inside code blocks
+- Dividers between subsections use --- (standard Markdown horizontal rule)
+- Approved symbols ONLY: checkmark (in prose), no random emoji
+- No emoji except approved list from ui-brand.md: checkmark, x, diamond, circle, lightning, warning
+- Consistent indentation and spacing
+
+**CRITICAL:**
+- Do NOT use proportional-font-dependent ASCII art outside code blocks
+- Do NOT use any emoji not in ui-brand.md approved list
+- Do NOT write "29 commands" — the correct count is 31
+- Do NOT write "13 agents" — the correct count is 16
+  </action>
+  <verify>
+1. `grep -c 'COMMANDS_PLACEHOLDER\|AGENTS_PLACEHOLDER\|SETTINGS_PLACEHOLDER' README.md` returns 3
+2. `grep -c '━━━' README.md` shows multiple section headers (at least 3 for the placeholder sections)
+3. `grep '```' README.md | wc -l` shows many fenced code blocks (banner, diagrams, trees all need them)
+4. `grep -c 'emoji\|🚀\|✨\|💫\|💡\|🔥' README.md` returns 0 (no unapproved emoji)
+5. The file has at least 200 lines: `wc -l README.md`
+  </verify>
+  <done>
+README.md exists with all 13 section positions established, 10 sections fully written (README-01,02,03,04,08,09,10,11,12,13), and 3 placeholder markers for commands/agents/settings tables that Plans 02 and 03 will fill.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- README.md contains a hero banner in a fenced code block with box-drawing characters
+- Core loop diagram present in fenced code block
+- Install section lists correct counts (16 agents, 31 commands)
+- Quick Start has 4 numbered steps
+- Three PLACEHOLDER markers present for subsequent plans
+- Architecture diagram in fenced code block with all 3 pipelines
+- Project structure trees in fenced code blocks
+- 6 workflow recipes present
+- Footer has MIT license + placeholder URLs
+- No unapproved emoji anywhere in the file
+</verification>
+
+<success_criteria>
+README.md is a complete document skeleton where a reader can see every section. The commands, agents, and settings sections have placeholder markers. All other sections have full content matching their requirements. All ASCII art is in fenced code blocks.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/v1.1/01-readme-rewrite/01-01-SUMMARY.md`
+</output>

--- a/.planning/phases/v1.1/01-readme-rewrite/01-01-SUMMARY.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-01-SUMMARY.md
@@ -1,0 +1,99 @@
+---
+phase: 01-readme-rewrite
+plan: 01
+subsystem: docs
+tags: [readme, ascii-art, markdown, branding, ui-brand]
+
+# Dependency graph
+requires: []
+provides:
+  - "Complete README.md skeleton with hero banner, all prose sections, and 3 placeholder markers"
+  - "ASCII art hero banner using box-drawing characters in fenced code block"
+  - "Core loop diagram, install section, quick start, CI integration, architecture, project structure, workflows, footer"
+affects: ["01-02-commands-reference", "01-03-agents-settings-reference", "01-04-polish"]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "All multi-line ASCII art in fenced code blocks for correct GitHub monospace rendering"
+    - "Section headers use ━━━ stage banner pattern from ui-brand.md inside code blocks"
+    - "Placeholder markers as HTML comments (<!-- COMMANDS_PLACEHOLDER -->) for plan-02/03 to fill"
+
+key-files:
+  created: []
+  modified:
+    - "README.md"
+
+key-decisions:
+  - "Use HTML comment markers (<!-- PLACEHOLDER -->) rather than text markers so they render invisibly if Plans 02-03 don't run"
+  - "Hero banner uses 62-character checkpoint box width (╔══╗ style) matching ui-brand.md checkpoint boxes"
+  - "Section dividers use stage banner pattern (━━━) inside fenced code blocks above each H2 heading"
+  - "Footer Discord and docs site URLs use placeholder values (discord.gg/vit-claude, vit-claude.dev) per research recommendation"
+  - "Update section merged into existing content flow rather than standalone section to reduce document length"
+
+patterns-established:
+  - "Section header pattern: fenced code block with ━━━ / VIT ► NAME / ━━━ immediately before the ## heading"
+  - "All ASCII art (banners, diagrams, trees) in triple-backtick fenced code blocks"
+
+# Metrics
+duration: 2min
+completed: 2026-03-19
+---
+
+# Phase v1.1/01 Plan 01: README Rewrite — Skeleton Summary
+
+**Complete README.md skeleton replacing the old 201-line minimal doc with a 372-line branded document: ASCII art hero banner, all 10 prose sections fully written, and 3 HTML comment placeholder markers for Plans 02 and 03 to fill.**
+
+## Performance
+
+- **Duration:** ~2 min
+- **Started:** 2026-03-19T10:14:48Z
+- **Completed:** 2026-03-19T10:16:30Z
+- **Tasks:** 1
+- **Files modified:** 1
+
+## Accomplishments
+
+- Replaced minimal README with fully structured 372-line document following all 13 requirements from 01-RESEARCH.md
+- All ASCII art (hero banner, section headers, architecture diagram, project structure trees) placed in fenced code blocks for correct GitHub rendering
+- Three placeholder markers inserted for Commands (Plan 02), Agents (Plan 03), and Settings (Plan 03) reference tables
+
+## Task Commits
+
+1. **Task 1: Create README.md with hero banner, intro sections, and full skeleton** - `dfb7b9e` (docs)
+
+## Files Created/Modified
+
+- `README.md` — Complete rewrite: 113 lines removed, 285 lines added; all sections from README-01 through README-13
+
+## Decisions Made
+
+- Used HTML comment markers (`<!-- COMMANDS_PLACEHOLDER -->`) rather than visible text placeholders — they render invisibly on GitHub if downstream plans don't fill them, which is cleaner than leaving `[PLACEHOLDER]` text visible
+- Hero banner uses 62-character width (checkpoint box style: `╔══════════════════════════════════════════════════════════════╗`) to match the ui-brand.md checkpoint box dimension, providing consistency with VIT's other visual outputs
+- Section dividers placed inside fenced code blocks using the stage banner pattern (`━━━ / VIT ► NAME / ━━━`) immediately before each `##` heading, keeping ASCII art in monospace while headings remain in proportional font for clickable anchor links
+- Footer Discord and docs URLs use placeholder values (`discord.gg/vit-claude`, `vit-claude.dev`) as flagged by research as open questions with no authoritative source in the repo
+- Merged the "Update" content as a standalone subsection rather than burying it in Install, making it easier for returning users to find the update command
+
+## Deviations from Plan
+
+None — plan executed exactly as written. All 13 section positions established, 10 sections fully written (README-01 through README-04, README-08 through README-13), 3 placeholder markers inserted (README-05, README-06, README-07).
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None — no external service configuration required.
+
+## Next Phase Readiness
+
+- `README.md` skeleton is complete and committed on `feature/v1.1-01-01`
+- Plan 02 (`01-02-PLAN.md`) needs to fill `<!-- COMMANDS_PLACEHOLDER -->` with the 31-command reference table organized in 11 groups
+- Plan 03 (`01-03-PLAN.md`) needs to fill `<!-- AGENTS_PLACEHOLDER -->` and `<!-- SETTINGS_PLACEHOLDER -->` with agent table and config.json reference
+- No blockers — all placeholder sections have matching markers and intro text ready
+
+---
+*Phase: v1.1/01-readme-rewrite*
+*Completed: 2026-03-19*

--- a/.planning/phases/v1.1/01-readme-rewrite/01-02-PLAN.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-02-PLAN.md
@@ -1,0 +1,161 @@
+---
+phase: 01-readme-rewrite
+plan: 02
+type: execute
+wave: 2
+depends_on: ["01-01"]
+files_modified: [README.md]
+autonomous: true
+assigned_to: ""
+execute_by: claude
+
+must_haves:
+  truths:
+    - "All 31 commands are documented with name, description, usage example, and produced artifacts"
+    - "Commands are organized into exactly 11 groups with ASCII section headers for each group"
+    - "Group counts sum to exactly 31 (3+4+2+2+2+4+2+2+3+3+4)"
+    - "Each command entry includes a usage example showing how to invoke it"
+    - "Each command entry lists what artifacts it produces (or None for commands that produce no files)"
+  artifacts:
+    - path: "README.md"
+      provides: "Complete commands reference section replacing COMMANDS_PLACEHOLDER"
+      contains: "Project Init"
+  key_links:
+    - from: "README.md"
+      to: ".claude/commands/vit/*.md"
+      via: "Descriptions extracted from frontmatter"
+      pattern: "/vit:"
+---
+
+<objective>
+Write the complete Commands Reference section (README-05) by reading all 31 command files and replacing the COMMANDS_PLACEHOLDER marker in README.md.
+
+Purpose: Document every command with name, description, usage example, and produced artifacts -- organized into 11 groups with ASCII section headers.
+
+Output: README.md with commands reference section fully populated.
+</objective>
+
+<execution_context>
+@./.claude/vit/workflows/execute-plan.md
+@./.claude/vit/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/v1.1/01-readme-rewrite/01-RESEARCH.md
+@.planning/phases/v1.1/01-readme-rewrite/01-01-SUMMARY.md
+@.claude/vit/references/ui-brand.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Read all 31 command files and extract reference data</name>
+  <files>README.md</files>
+  <action>
+Read the `description:` frontmatter field and the `<objective>` section from each of the 31 command files in `.claude/commands/vit/`. For each command, extract:
+
+1. **Name**: The `/vit:<name>` format (derived from filename without .md extension)
+2. **Description**: From the `description:` frontmatter field
+3. **Usage example**: Derive from the command's typical invocation. For commands that take arguments (like plan-phase taking a phase number), show the argument. For commands with no arguments, show just the command name.
+4. **Produced artifacts**: What files/outputs the command creates. Look for mentions of output files in the objective or execution steps. If a command produces no files (like /vit:help, /vit:join-discord), write "None" or a dash.
+
+Organize into the 11 groups verified in the research:
+
+| # | Group | Commands (31 total) |
+|---|-------|---------------------|
+| 1 | Project Init | new-project, new-milestone, map-codebase |
+| 2 | Planning | plan-phase, discuss-phase, research-phase, list-phase-assumptions |
+| 3 | Execution | execute-phase, quick |
+| 4 | Verification | verify-work, audit-milestone |
+| 5 | Progress | progress, list-milestones |
+| 6 | Roadmap | add-phase, insert-phase, remove-phase, plan-milestone-gaps |
+| 7 | Session | pause-work, resume-work |
+| 8 | Team | assign-phase, team-status |
+| 9 | Maintenance | complete-milestone, review-feedback, debug |
+| 10 | Config | settings, set-profile, update |
+| 11 | Meta | help, join-discord, add-todo, check-todos |
+  </action>
+  <verify>
+Count command files read: should be exactly 31.
+  </verify>
+  <done>All 31 command files read and data extracted into the 11-group structure.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Write the commands reference section into README.md</name>
+  <files>README.md</files>
+  <action>
+Replace the `<!-- COMMANDS_PLACEHOLDER -->` marker in README.md with the full commands reference.
+
+**Format for each group:**
+
+Each group gets a sub-heading (### Group Name) and a table or structured list. Use this format for each command entry:
+
+```markdown
+#### `/vit:command-name`
+Description from frontmatter.
+
+**Usage:** `/vit:command-name [args]`
+**Produces:** `ARTIFACT.md` (or None)
+```
+
+Alternatively, if the above is too verbose and would make the section excessively long, use a compact table format per group:
+
+```markdown
+### Group Name
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:new-project` | Initialize project... | `/vit:new-project` | PROJECT.md, ROADMAP.md |
+```
+
+Choose the format that keeps the section readable but complete. The table format is preferred for density.
+
+**Each group header** should have a small ASCII divider inside a code block:
+```
+───────────────────────────────────────────
+ GROUP NAME
+───────────────────────────────────────────
+```
+
+**CRITICAL rules:**
+- Exactly 31 commands total across all groups
+- Every command from the 11-group table above MUST appear
+- Do NOT skip any command
+- Do NOT invent commands that don't exist
+- Descriptions must come from the actual frontmatter, not from memory
+- After writing, count all commands in the section to verify 31
+  </action>
+  <verify>
+1. `grep -c 'COMMANDS_PLACEHOLDER' README.md` returns 0 (placeholder replaced)
+2. Count all `/vit:` entries in the commands section — must be exactly 31
+3. Verify all 11 group headers present: grep for "Project Init", "Planning", "Execution", "Verification", "Progress", "Roadmap", "Session", "Team", "Maintenance", "Config", "Meta"
+4. Spot-check: /vit:assign-phase and /vit:team-status present (the two newest commands often missed)
+  </verify>
+  <done>
+Commands reference section is complete with all 31 commands in 11 groups. Each command has name, description, usage example, and produced artifacts. The COMMANDS_PLACEHOLDER marker is gone.
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+- COMMANDS_PLACEHOLDER marker no longer in README.md
+- Exactly 31 commands documented
+- Exactly 11 group sections present
+- Each command has: name, description, usage, artifacts
+- No commands invented that don't exist as .md files
+- No existing commands missing from the reference
+- ASCII group dividers are inside fenced code blocks
+</verification>
+
+<success_criteria>
+The Commands Reference section of README.md is complete, accurate, and contains all 31 commands organized into 11 groups. Each entry has the four required data points. The section matches the content of the actual command files.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/v1.1/01-readme-rewrite/01-02-SUMMARY.md`
+</output>

--- a/.planning/phases/v1.1/01-readme-rewrite/01-02-SUMMARY.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-02-SUMMARY.md
@@ -1,0 +1,98 @@
+---
+phase: 01-readme-rewrite
+plan: 02
+subsystem: docs
+tags: [readme, commands-reference, markdown, documentation]
+
+# Dependency graph
+requires:
+  - phase: 01-01
+    provides: "README.md skeleton with COMMANDS_PLACEHOLDER marker at line 97"
+provides:
+  - "Complete Commands Reference section with all 31 commands in 11 groups"
+  - "Each command documented with name, description, usage example, and produced artifacts"
+  - "Descriptions sourced directly from .claude/commands/vit/ frontmatter"
+affects: ["01-03-agents-settings-reference", "01-04-polish"]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Commands reference uses compact table format (Command | Description | Usage | Produces) per group"
+    - "Each group has ASCII divider in fenced code block followed by ### heading and table"
+    - "Group structure: 11 groups with counts 3+4+2+2+2+4+2+2+3+3+4 = 31"
+
+key-files:
+  created: []
+  modified:
+    - "README.md"
+
+key-decisions:
+  - "Compact table format chosen over per-command headings (#### /vit:name) for density — 31 entries fit cleanly in 11 tables"
+  - "ASCII dividers in fenced code blocks above each ### group heading, matching the section header pattern from Plan 01"
+  - "Descriptions taken verbatim from description: frontmatter field of each command file"
+  - "Produced artifacts column uses backtick-formatted file paths or None for commands with no output"
+
+patterns-established:
+  - "Group header pattern: fenced code block with ─── / GROUP NAME / ─── then ### heading then table"
+
+# Metrics
+duration: 2min
+completed: 2026-03-19
+---
+
+# Phase v1.1/01 Plan 02: Commands Reference Summary
+
+**All 31 VIT commands documented in compact table format across 11 groups with ASCII section headers — descriptions sourced from frontmatter, artifacts and usage derived from each command's objective.**
+
+## Performance
+
+- **Duration:** ~2 min
+- **Started:** 2026-03-19T10:18:30Z
+- **Completed:** 2026-03-19T10:20:28Z
+- **Tasks:** 2
+- **Files modified:** 1
+
+## Accomplishments
+
+- Read all 31 command files from `.claude/commands/vit/` and extracted name, description, usage, and produced artifacts
+- Replaced `<!-- COMMANDS_PLACEHOLDER -->` with 151-line commands reference section
+- 31 commands organized into 11 groups with ASCII dividers, verified by `grep -o '/vit:...' | sort -u | wc -l` = 31
+
+## Task Commits
+
+1. **Task 1: Read all 31 command files and extract reference data** — no commit (read-only data gathering)
+2. **Task 2: Write the commands reference section into README.md** — `80bd42e` (docs)
+
+## Files Created/Modified
+
+- `README.md` — Commands Reference section added (lines 97–248): 151 insertions, 1 deletion (placeholder removed)
+
+## Decisions Made
+
+- Compact table format (not per-command `####` headings) chosen for density — 31 commands in 11 tables reads better than 31 individual subsections
+- ASCII dividers use `───` style inside fenced code blocks, consistent with Plan 01's section header pattern for the Commands section
+- Descriptions copied verbatim from `description:` frontmatter field — no paraphrasing
+- `/vit:set-profile` included even though its frontmatter shows `name: set-profile` (missing `vit:` prefix) — the command is invoked as `/vit:set-profile` per the plan's 11-group table
+
+## Deviations from Plan
+
+None — plan executed exactly as written. All 31 commands documented, all 11 groups present, placeholder removed, group counts match specification (3+4+2+2+2+4+2+2+3+3+4 = 31).
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None — no external service configuration required.
+
+## Next Phase Readiness
+
+- `README.md` Commands Reference section is complete and committed on `feature/v1.1-01-02`
+- Plan 03 (`01-03-PLAN.md`) needs to fill `<!-- AGENTS_PLACEHOLDER -->` and `<!-- SETTINGS_PLACEHOLDER -->` with the agents table and config.json settings reference
+- No blockers — the two remaining placeholder markers are in place at their expected locations
+
+---
+*Phase: v1.1/01-readme-rewrite*
+*Completed: 2026-03-19*

--- a/.planning/phases/v1.1/01-readme-rewrite/01-03-PLAN.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-03-PLAN.md
@@ -1,0 +1,162 @@
+---
+phase: 01-readme-rewrite
+plan: 03
+type: execute
+wave: 3
+depends_on: ["01-02"]
+files_modified: [README.md]
+autonomous: true
+assigned_to: ""
+execute_by: claude
+
+must_haves:
+  truths:
+    - "All 16 agents are documented in a table with spawner command, role description, and output artifact"
+    - "All config.json keys are documented with defaults and descriptions"
+    - "Model profile matrix table is present showing all agents across quality/balanced/budget profiles"
+    - "Agent count in the section matches exactly 16"
+    - "Config keys include mode, depth, parallelization, commit_docs, model_profile, workflow.*, team.*"
+  artifacts:
+    - path: "README.md"
+      provides: "Complete agents reference and settings reference sections"
+      contains: "vit-planner"
+  key_links:
+    - from: "README.md"
+      to: ".claude/agents/vit-*.md"
+      via: "Agent descriptions extracted from frontmatter"
+      pattern: "vit-.*\\|"
+    - from: "README.md"
+      to: ".claude/vit/references/model-profiles.md"
+      via: "Model profile matrix copied"
+      pattern: "quality.*balanced.*budget"
+---
+
+<objective>
+Write the Agents Reference (README-06) and Settings Reference (README-07) sections by reading all 16 agent files and the config reference files, replacing AGENTS_PLACEHOLDER and SETTINGS_PLACEHOLDER markers.
+
+Purpose: Complete the two remaining reference sections so the README has full documentation of all agents and all configuration options.
+
+Output: README.md with agents and settings sections fully populated.
+</objective>
+
+<execution_context>
+@./.claude/vit/workflows/execute-plan.md
+@./.claude/vit/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/v1.1/01-readme-rewrite/01-RESEARCH.md
+@.planning/phases/v1.1/01-readme-rewrite/01-02-SUMMARY.md
+@.claude/vit/references/ui-brand.md
+@.claude/vit/references/planning-config.md
+@.claude/vit/references/model-profiles.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Write the Agents Reference section</name>
+  <files>README.md</files>
+  <action>
+Read the `description:` frontmatter from all 16 agent files in `.claude/agents/vit-*.md`. For each agent, extract:
+
+1. **Agent name**: From the `name:` frontmatter field (e.g., vit-planner)
+2. **Spawner command**: From the description field — each agent mentions "Spawned by /vit:xxx" in its description
+3. **Role description**: A concise description of what the agent does (from the description field)
+4. **Output artifact**: What file(s) the agent produces (from the description field or objective section)
+
+The 16 agents are:
+vit-planner, vit-executor, vit-verifier, vit-phase-researcher, vit-plan-checker, vit-project-researcher, vit-research-synthesizer, vit-roadmapper, vit-codebase-mapper, vit-integration-checker, vit-debugger, vit-github-reviewer, vit-test-writer, vit-pr-reviewer, vit-doc-updater, vit-changelog-writer
+
+Replace `<!-- AGENTS_PLACEHOLDER -->` in README.md with a table:
+
+```markdown
+| Agent | Spawned By | Role | Output |
+|-------|------------|------|--------|
+| `vit-planner` | `/vit:plan-phase` | Creates executable phase plans... | PLAN.md |
+| ... | ... | ... | ... |
+```
+
+**CRITICAL:**
+- Exactly 16 agents in the table
+- Descriptions from actual frontmatter, not from memory
+- Every agent file in .claude/agents/vit-*.md must appear
+  </action>
+  <verify>
+1. `grep -c 'AGENTS_PLACEHOLDER' README.md` returns 0
+2. Count `vit-` entries in the agents table — must be exactly 16
+3. Spot-check: vit-pr-reviewer, vit-doc-updater, vit-changelog-writer present (the three newest agents)
+  </verify>
+  <done>Agents reference table complete with all 16 agents, each having spawner, role, and output columns.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Write the Settings Reference section</name>
+  <files>README.md</files>
+  <action>
+Replace `<!-- SETTINGS_PLACEHOLDER -->` in README.md with the complete settings reference.
+
+**Part A: config.json keys table**
+
+Read `.claude/vit/references/planning-config.md` and the actual `.planning/config.json` to produce a complete keys table. The keys are:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `mode` | `"yolo"` | Execution mode (yolo = no confirmations, interactive = confirm each step) |
+| `depth` | `"standard"` | Planning depth (quick, standard, comprehensive) |
+| `parallelization` | `true` | Enable parallel agent spawning in execute-phase |
+| `commit_docs` | `true` | Commit .planning/ artifacts to git |
+| `model_profile` | `"balanced"` | Agent model selection profile (quality, balanced, budget) |
+| `workflow.research` | `true` | Enable research step in plan-phase |
+| `workflow.plan_check` | `true` | Enable plan checker before execution |
+| `workflow.verifier` | `true` | Enable verifier after execution |
+| `team.enabled` | `false` | Enable team mode for multi-engineer collaboration |
+| `team.roster` | `[]` | Array of {handle, role} engineer objects |
+| `team.default_reviewer` | `""` | GitHub handle for auto-assigning PR reviewer |
+
+Show a sample config.json in a fenced code block with all keys at their defaults.
+
+**Part B: Model Profile Matrix**
+
+Copy the model profile matrix from `.claude/vit/references/model-profiles.md` into the settings section. This is the table showing which Claude model each agent uses under each profile (quality/balanced/budget). Include it as a Markdown table.
+
+Add brief explanations of each profile:
+- **quality**: Maximum reasoning — Opus for all decision-making agents
+- **balanced** (default): Opus for planning, Sonnet for execution and verification
+- **budget**: Minimal Opus — Sonnet for code, Haiku for research/verification
+
+Show how to switch: `/vit:set-profile <profile>` or edit config.json.
+
+**CRITICAL:**
+- Include ALL keys from the table above — do not skip team.* or workflow.* keys
+- Model matrix must match model-profiles.md exactly (11 agents x 3 profiles)
+  </action>
+  <verify>
+1. `grep -c 'SETTINGS_PLACEHOLDER' README.md` returns 0
+2. All 11 config keys present in the table
+3. Model profile matrix present with quality/balanced/budget columns
+4. Sample config.json code block present
+  </verify>
+  <done>Settings reference complete with all config keys documented, sample config shown, and model profile matrix included.</done>
+</task>
+
+</tasks>
+
+<verification>
+- AGENTS_PLACEHOLDER and SETTINGS_PLACEHOLDER markers no longer in README.md
+- Exactly 16 agents in the agents table
+- All 11 config.json keys documented with correct defaults
+- Model profile matrix matches model-profiles.md (11 agents x 3 profiles)
+- No placeholder markers remain anywhere in README.md
+</verification>
+
+<success_criteria>
+Both reference sections are complete. The agents table has all 16 agents with spawner, role, and output. The settings section has all config keys, a sample config, and the model profile matrix. Zero placeholder markers remain in README.md.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/v1.1/01-readme-rewrite/01-03-SUMMARY.md`
+</output>

--- a/.planning/phases/v1.1/01-readme-rewrite/01-03-SUMMARY.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-03-SUMMARY.md
@@ -1,0 +1,102 @@
+---
+phase: 01-readme-rewrite
+plan: 03
+subsystem: docs
+tags: [readme, agents, settings, config, model-profiles]
+
+requires:
+  - phase: v1.1/01-plan-02
+    provides: Commands Reference table written into README.md (COMMANDS_PLACEHOLDER replaced)
+
+provides:
+  - Agents Reference table with all 16 VIT agents (AGENTS_PLACEHOLDER replaced)
+  - Settings Reference with 11 config.json keys, sample config, and model profile matrix (SETTINGS_PLACEHOLDER replaced)
+
+affects: [v1.1/01-plan-04]
+
+tech-stack:
+  added: []
+  patterns:
+    - "Agent table: Agent | Spawned By | Role | Output columns"
+    - "Config keys table: Key | Default | Description with inline code formatting"
+    - "Model profile matrix: Agent | quality | balanced | budget"
+
+key-files:
+  created: []
+  modified:
+    - README.md
+
+key-decisions:
+  - "Descriptions sourced directly from frontmatter of each agent file — not from memory"
+  - "vit-verifier and vit-integration-checker spawn source identified via command files (execute-phase and audit-milestone) since their own descriptions omit 'Spawned by'"
+  - "Model profile matrix matches model-profiles.md exactly (11 agents, 3 profiles)"
+  - "Sample config.json shows all 11 keys at their documented defaults"
+
+patterns-established:
+  - "Agent docs: spawn source, role, output artifact as table columns"
+  - "Config docs: default values shown in backtick code style, nested keys use dot notation"
+
+duration: 2min
+completed: 2026-03-19
+---
+
+# Phase v1.1/01 Plan 03: Agents Reference and Settings Reference Summary
+
+**16-agent table with spawner/role/output columns and full settings reference (11 config keys + model profile matrix) written into README.md**
+
+## Performance
+
+- **Duration:** ~2 min
+- **Started:** 2026-03-19T10:23:26Z
+- **Completed:** 2026-03-19T10:25:02Z
+- **Tasks:** 2
+- **Files modified:** 1
+
+## Accomplishments
+
+- Replaced `<!-- AGENTS_PLACEHOLDER -->` with a 16-row table documenting every VIT agent with spawner command, role description, and output artifact
+- Replaced `<!-- SETTINGS_PLACEHOLDER -->` with complete settings reference: 11 config.json keys table, sample config block, and model profile matrix
+- Model profile matrix (11 agents x quality/balanced/budget) copied exactly from model-profiles.md
+- Zero placeholder markers remain in README.md
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Write the Agents Reference section** - `7a4f28a` (feat)
+2. **Task 2: Write the Settings Reference section** - `159091f` (feat)
+
+**Plan metadata:** (docs commit follows)
+
+## Files Created/Modified
+
+- `README.md` — AGENTS_PLACEHOLDER replaced with 16-agent table; SETTINGS_PLACEHOLDER replaced with config keys table, sample config, and model profile matrix
+
+## Decisions Made
+
+- Descriptions sourced from actual agent file frontmatter, not from memory
+- For `vit-verifier` and `vit-integration-checker`, which lack "Spawned by" in their `description:` field, the spawner was identified from command files (`execute-phase.md` spawns vit-verifier; `audit-milestone.md` spawns vit-integration-checker)
+- config.json sample shows all 11 keys at their documented defaults (matching planning-config.md)
+- Model profile matrix matches model-profiles.md exactly — 11 agents, 3 profiles, no additions or omissions
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- README.md now has Agents Reference and Settings Reference complete
+- Two placeholder markers replaced, zero remaining
+- Ready for Plan 04 (final README section or polish pass)
+
+---
+*Phase: v1.1/01-readme-rewrite*
+*Completed: 2026-03-19*

--- a/.planning/phases/v1.1/01-readme-rewrite/01-04-PLAN.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-04-PLAN.md
@@ -1,0 +1,137 @@
+---
+phase: 01-readme-rewrite
+plan: 04
+type: execute
+wave: 4
+depends_on: ["01-03"]
+files_modified: [README.md]
+autonomous: false
+assigned_to: ""
+execute_by: claude
+
+must_haves:
+  truths:
+    - "Visual style is consistent throughout: section headers use fenced-code-block banners, no unapproved emoji"
+    - "All ASCII art renders correctly — every multi-line ASCII construction is inside a fenced code block"
+    - "Command count is exactly 31, agent count is exactly 16"
+    - "No placeholder markers remain in the document"
+    - "The README renders correctly when viewed on GitHub"
+  artifacts:
+    - path: "README.md"
+      provides: "Final polished README with consistent visual style"
+      min_lines: 400
+  key_links:
+    - from: "README.md"
+      to: ".claude/vit/references/ui-brand.md"
+      via: "Style consistency verification"
+      pattern: "approved symbols only"
+---
+
+<objective>
+Perform a final style consistency pass on README.md (README-12) and then present a human verification checkpoint for visual review.
+
+Purpose: Ensure the complete README meets all 13 requirements with consistent visual branding before the phase is considered done.
+
+Output: Polished README.md ready for merge.
+</objective>
+
+<execution_context>
+@./.claude/vit/workflows/execute-plan.md
+@./.claude/vit/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/v1.1/01-readme-rewrite/01-RESEARCH.md
+@.planning/phases/v1.1/01-readme-rewrite/01-03-SUMMARY.md
+@.claude/vit/references/ui-brand.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Style consistency pass and final polish</name>
+  <files>README.md</files>
+  <action>
+Read the complete README.md and perform a thorough style consistency audit against ui-brand.md and README-12 requirements:
+
+**Check 1: ASCII art in code blocks**
+- Every multi-line ASCII art element (banner, section headers, diagrams, trees) MUST be inside a fenced code block
+- Single-line dividers using `---` (Markdown HR) are fine outside code blocks
+- Fix any ASCII art found outside code blocks
+
+**Check 2: Emoji audit**
+- Approved symbols ONLY: checkmark, x-mark, diamond, circle, lightning, warning, party (milestone banner only)
+- Specifically banned: no random emoji used for decoration
+- Fix any unapproved emoji by removing them or replacing with approved symbols
+
+**Check 3: Section header consistency**
+- Major sections (Commands, Agents, Settings, Architecture, etc.) should have the ━━━ banner pattern inside fenced code blocks
+- Minor subsections use standard Markdown headings (##, ###)
+- Banner widths should be consistent (pick 53-char stage banner width from ui-brand.md)
+
+**Check 4: Counts verification**
+- Verify exactly 31 commands documented (count them)
+- Verify exactly 16 agents documented (count them)
+- Verify all 11 config keys documented
+- If any count is wrong, fix it
+
+**Check 5: Placeholder cleanup**
+- Confirm zero HTML comment placeholders remain (`<!-- *_PLACEHOLDER -->`)
+- Remove any TODO/FIXME/TBD comments except the legitimate footer placeholder URLs
+
+**Check 6: Overall polish**
+- Consistent spacing between sections
+- No duplicate horizontal rules
+- Table alignment (pipes should be consistent)
+- Links format correctly (relative paths for repo files, absolute for external)
+- Built with GSD section should be preserved if still relevant, or removed if it feels out of place in the new structure
+
+Fix any issues found. If the README is already clean, make no changes.
+  </action>
+  <verify>
+1. `grep -cP '[\x{1F680}\x{2728}\x{1F4AB}\x{1F4A1}\x{1F525}]' README.md` returns 0 (no banned emoji — note: use grep -P for unicode)
+2. `grep -c 'PLACEHOLDER' README.md` returns 0
+3. `wc -l README.md` shows 400+ lines (comprehensive README)
+4. All section headers present in correct order
+  </verify>
+  <done>README.md passes all style consistency checks. No unapproved emoji, all ASCII art in code blocks, consistent banner widths, correct counts.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>Complete README.md with all 13 requirements: ASCII hero banner, What is VIT, Install, Quick Start, Commands Reference (31 commands / 11 groups), Agents Reference (16 agents), Settings Reference (config keys + model matrix), GitHub CI Integration, Architecture Diagram, Project Structure, Common Workflows (6 recipes), consistent ASCII branding, and Footer.</what-built>
+  <how-to-verify>
+1. Push the branch and view README.md on GitHub to verify ASCII art rendering
+2. Check the hero banner renders with correct alignment in the code block
+3. Scroll through all section headers — they should have consistent ━━━ banners
+4. Verify the architecture diagram is readable and aligned
+5. Check the project structure trees are properly formatted
+6. Confirm commands table has all 31 entries (spot-check: assign-phase, team-status)
+7. Confirm agents table has all 16 entries (spot-check: vit-pr-reviewer, vit-doc-updater)
+8. Confirm settings section has model profile matrix
+9. Check no random emoji appear anywhere
+10. Verify footer links are present (even if placeholder URLs)
+
+Alternative local preview: Use a Markdown preview tool or `grip README.md` to render locally.
+  </how-to-verify>
+  <resume-signal>Type "approved" or describe issues to fix</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+- All 13 README requirements (README-01 through README-13) are met
+- Visual style is consistent throughout per README-12
+- ASCII art renders correctly on GitHub (in fenced code blocks)
+- Human has visually verified the rendering
+</verification>
+
+<success_criteria>
+The README.md is complete, polished, visually consistent, and human-approved. All 13 requirements are satisfied. The document is ready for merge.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/v1.1/01-readme-rewrite/01-04-SUMMARY.md`
+</output>

--- a/.planning/phases/v1.1/01-readme-rewrite/01-04-SUMMARY.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-04-SUMMARY.md
@@ -1,0 +1,99 @@
+---
+phase: 01-readme-rewrite
+plan: 04
+subsystem: docs
+tags: [readme, style, ascii-art, branding, consistency]
+
+requires:
+  - phase: v1.1/01-plan-03
+    provides: Agents Reference (16 agents) and Settings Reference (11 config keys + model profile matrix) written into README.md
+
+provides:
+  - Style consistency audit confirming README.md passes all 6 checks
+  - Confirmed: 31 commands, 16 agents, 11 config keys, 0 placeholders, consistent 53-char banners
+  - README.md ready for human visual review and merge
+
+affects: [v1.1/02-docs-site]
+
+tech-stack:
+  added: []
+  patterns:
+    - "All ASCII art (banners, dividers, diagrams, trees) inside fenced code blocks"
+    - "Section banners: 53-char ━━━ VIT ► SECTION ━━━ pattern"
+    - "Group dividers: 43-char ─── GROUP NAME ─── pattern inside fenced code blocks"
+
+key-files:
+  created: []
+  modified:
+    - README.md (no changes — already clean from plans 01-03)
+
+key-decisions:
+  - "Emoji in fenced code block CI examples (✅ ❌ 🔄) are acceptable — they represent literal GitHub comment output, not decorative document emoji"
+  - "No changes made — README passed all 6 style checks as written"
+
+patterns-established:
+  - "Style audit pattern: check ASCII art containment, emoji presence, banner widths, counts, placeholders, then overall polish"
+
+duration: 3min
+completed: 2026-03-19
+---
+
+# Phase v1.1/01 Plan 04: Style Consistency Pass Summary
+
+**README.md passed all 6 style checks without modification — consistent 53-char banners, zero placeholders, 31 commands / 16 agents confirmed, all ASCII art in fenced code blocks**
+
+## Performance
+
+- **Duration:** ~3 min
+- **Started:** 2026-03-19T10:28:25Z
+- **Completed:** 2026-03-19T10:31:00Z
+- **Tasks:** 1 of 2 (Task 2 is a human checkpoint)
+- **Files modified:** 0 (README already clean)
+
+## Accomplishments
+
+- Performed full 6-check style audit: ASCII art containment, emoji, banner widths, counts, placeholders, overall polish
+- Confirmed all 31 commands present in table (11 groups: Project Init, Planning, Execution, Verification, Progress, Roadmap, Session, Team, Maintenance, Config, Meta)
+- Confirmed all 16 agents present in table
+- Confirmed all 11 config.json keys documented
+- Confirmed zero PLACEHOLDER markers remain
+- Confirmed all section banners are consistently 53 chars wide with `━━━ VIT ► SECTION ━━━` pattern
+- Confirmed all ASCII art (hero banner, group dividers, architecture diagram, project structure trees) is inside fenced code blocks
+- Identified emoji only in CI example code blocks (✅ ❌ 🔄) — appropriate since they represent literal GitHub comment output
+
+## Task Commits
+
+Task 1 required no commit (no changes made — README already clean).
+
+**Human checkpoint (Task 2):** Awaiting visual review before plan metadata commit.
+
+## Files Created/Modified
+
+- `README.md` — No changes. Passed all style consistency checks as-is.
+
+## Decisions Made
+
+- Emoji `✅`, `❌`, `🔄` inside fenced CI example code blocks are acceptable — they are literal representations of what GitHub CI posts, not decorative document emoji
+- No changes required — all prior plans (01-01 through 01-03) produced a consistent, clean README
+
+## Deviations from Plan
+
+None - plan executed exactly as written. README was already clean.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- README.md is complete and consistent — all 13 requirements satisfied
+- Awaiting human visual verification (Task 2 checkpoint) before PR merge
+- After approval: PR #53 ready to merge into main
+
+---
+*Phase: v1.1/01-readme-rewrite*
+*Completed: 2026-03-19*

--- a/.planning/phases/v1.1/01-readme-rewrite/01-05-PLAN.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-05-PLAN.md
@@ -1,0 +1,126 @@
+---
+phase: 01-readme-rewrite
+plan: 05
+type: execute
+wave: 1
+depends_on: []
+files_modified: [README.md]
+autonomous: true
+gap_closure: true
+
+must_haves:
+  truths:
+    - "Hero banner VIT branding renders as large ASCII art block letters"
+    - "VIT ASCII art has color visible on GitHub"
+  artifacts:
+    - path: "README.md"
+      provides: "Hero banner with figlet-style VIT branding and color"
+      contains: "large multi-line ASCII art letters spelling VIT"
+  key_links:
+    - from: "README.md"
+      to: "GitHub rendering"
+      via: "diff syntax highlighting or HTML color spans"
+      pattern: "(diff|<span|<font|style=)"
+---
+
+<objective>
+Replace the plain text "VIT" in the README hero banner with large figlet-style ASCII art letters and add GitHub-compatible color.
+
+Purpose: The UAT identified that the hero banner uses plain text "VIT >" instead of the intended large ASCII art branding with color.
+Output: Updated README.md lines 1-9 with ASCII art VIT lettering and color markup.
+</objective>
+
+<execution_context>
+@./.claude/vit/workflows/execute-plan.md
+@./.claude/vit/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@README.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Replace hero banner with ASCII art VIT branding and color</name>
+  <files>README.md</files>
+  <action>
+Replace lines 1-9 of README.md (the current hero banner inside the fenced code block) with a new hero banner that:
+
+1. Uses large figlet-style block letters for "VIT". Use this exact ASCII art:
+
+```
+██╗   ██╗██╗████████╗
+██║   ██║██║╚══██╔══╝
+██║   ██║██║   ██║
+╚██╗ ██╔╝██║   ██║
+ ╚████╔╝ ██║   ██║
+  ╚═══╝  ╚═╝   ╚═╝
+```
+
+2. Apply color using a GitHub-compatible technique. Use a diff code block so the ASCII art lines get green color highlighting. The approach:
+   - Open with ` ```diff ` (diff-highlighted fenced code block)
+   - Prefix each ASCII art line with `+` so GitHub renders them in green
+   - Include the subtitle lines WITHOUT the `+` prefix so they render as neutral/white
+   - Close with ` ``` `
+
+3. Keep the subtitle content from the original banner but place it below the ASCII art (still inside the same diff block). Specifically:
+   - One blank line after the ASCII art
+   - `  Phase-based project execution for Claude Code` (no +, renders neutral)
+   - blank line
+   - `  Plan  >  Execute  >  Verify  >  Merge` (no +, renders neutral)
+   - `  Atomic commits · Parallel agents · GitHub CI feedback` (no +, renders neutral)
+
+4. Do NOT use the box-drawing frame (the old approach with the box is gone). The diff block itself provides visual framing.
+
+5. Do NOT change anything else in the README beyond lines 1-9 (the fenced code block and its contents). The line immediately after (line 11: "Phase-based project execution framework...") and everything below stays exactly as-is.
+
+The final result for the top of README.md should look like:
+
+````
+```diff
++██╗   ██╗██╗████████╗
++██║   ██║██║╚══██╔══╝
++██║   ██║██║   ██║
++╚██╗ ██╔╝██║   ██║
++ ╚████╔╝ ██║   ██║
++  ╚═══╝  ╚═╝   ╚═╝
+
+  Phase-based project execution for Claude Code
+
+  Plan  >  Execute  >  Verify  >  Merge
+  Atomic commits · Parallel agents · GitHub CI feedback
+```
+````
+
+IMPORTANT: Use the Unicode block characters (U+2588 FULL BLOCK, U+2551 BOX DRAWINGS DOUBLE VERTICAL, etc.) exactly as shown — these are the same characters used in "ANSI Shadow" figlet font style. Do NOT substitute with hash marks or other approximations.
+  </action>
+  <verify>
+    1. `head -15 README.md` shows the diff block with ASCII art VIT letters prefixed by +
+    2. The rest of the README (line 13 onward) is unchanged: `diff <(git show HEAD:README.md | tail -n +11) <(tail -n +13 README.md)` produces no output (content after banner is identical, accounting for the line shift)
+  </verify>
+  <done>README hero banner displays large figlet-style "VIT" ASCII art letters inside a diff code block (green-colored on GitHub), with subtitle text below. No other README content changed.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `head -15 README.md` shows diff code block with ASCII art
+- ASCII art lines start with `+` for green highlighting
+- Subtitle lines do NOT start with `+` (neutral color)
+- Rest of README unchanged
+</verification>
+
+<success_criteria>
+- VIT rendered as large multi-line ASCII art block letters (6 lines tall)
+- Color applied via diff syntax highlighting (+ prefix = green on GitHub)
+- Subtitle text preserved below the art
+- No regressions to rest of README content
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/v1.1/01-readme-rewrite/01-05-SUMMARY.md`
+</output>

--- a/.planning/phases/v1.1/01-readme-rewrite/01-05-SUMMARY.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-05-SUMMARY.md
@@ -1,0 +1,97 @@
+---
+phase: 01-readme-rewrite
+plan: 05
+subsystem: ui
+tags: [readme, ascii-art, branding, diff-highlighting, github-rendering]
+
+# Dependency graph
+requires:
+  - phase: 01-readme-rewrite
+    provides: README.md with box-drawing hero banner from Plan 01
+provides:
+  - README hero banner with figlet-style ANSI Shadow ASCII art for "VIT" rendered green via diff syntax highlighting
+affects: [future README edits, marketing, onboarding]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "diff code block with + prefix lines for green GitHub color highlighting"
+    - "ANSI Shadow figlet font style (U+2588 FULL BLOCK, U+2551 BOX DRAWINGS DOUBLE VERTICAL) for ASCII art branding"
+
+key-files:
+  created: []
+  modified:
+    - README.md
+
+key-decisions:
+  - "Use diff code block (not HTML spans or font tags) for color — broadest GitHub compatibility"
+  - "Subtitle lines kept without + prefix so they render neutral/white, contrasting with the green art"
+  - "Removed old box-drawing frame (╔══╗) — diff block provides sufficient visual framing"
+
+patterns-established:
+  - "Figlet ANSI Shadow style for VIT branding: 6-line tall block letters with double-line box characters"
+
+# Metrics
+duration: 1min
+completed: 2026-03-19
+---
+
+# Phase 01 Plan 05: Gap Closure — ASCII Art Hero Banner Summary
+
+**ANSI Shadow block-letter VIT branding inside a diff code block, rendering green on GitHub via + prefix syntax**
+
+## Performance
+
+- **Duration:** ~1 min
+- **Started:** 2026-03-19T00:00:00Z
+- **Completed:** 2026-03-19T00:01:00Z
+- **Tasks:** 1 of 1
+- **Files modified:** 1
+
+## Accomplishments
+
+- Replaced plain-text "VIT >" box banner with 6-line ANSI Shadow ASCII art block letters
+- Applied GitHub-compatible green color via diff code block + prefix technique
+- Preserved all subtitle text below the art (neutral color, no + prefix)
+- Zero regressions: all README content from line 14 onward confirmed identical to previous HEAD
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Replace hero banner with ASCII art VIT branding and color** - `47de10c` (feat)
+
+**Plan metadata:** (docs commit follows)
+
+## Files Created/Modified
+
+- `README.md` — Lines 1-13 replaced: diff block with ANSI Shadow VIT ASCII art and subtitle text
+
+## Decisions Made
+
+- Used diff code block for color: works on github.com and all GitHub-rendered Markdown without JavaScript or HTML injection
+- Kept subtitle lines (Plan, Execute, Verify, Merge / Atomic commits line) without `+` prefix so they appear in neutral color, providing visual separation from the green branding
+- Removed the old `╔══╗` box frame entirely — the fenced code block provides sufficient visual boundary
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- README hero banner now matches the intended design from the original spec
+- Gap closure complete: UAT concern about plain-text branding is resolved
+- Phase 01 (README Rewrite) is fully complete — all 5 plans executed
+
+---
+*Phase: 01-readme-rewrite*
+*Completed: 2026-03-19*

--- a/.planning/phases/v1.1/01-readme-rewrite/01-RESEARCH.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-RESEARCH.md
@@ -1,0 +1,344 @@
+# Phase 01: README Rewrite with ASCII Art Branding - Research
+
+**Researched:** 2026-03-19
+**Domain:** Technical documentation / Markdown README authoring with ASCII art branding
+**Confidence:** HIGH
+
+---
+
+## Summary
+
+This phase is a pure documentation writing task — no code to implement. The deliverable is a single `README.md` file that replaces the existing one. All content sources already exist in the repository: 31 command files, 16 agent files, `ui-brand.md`, `planning-config.md`, `model-profiles.md`, and `phase-ci.yml`. The research job is to understand the constraints and patterns for the output document, not to discover external libraries.
+
+The primary technical challenge is GitHub rendering of ASCII art / box-drawing characters. Research confirms: box-drawing characters (━, ─, ╔, ║, etc.) must be placed inside fenced code blocks (triple backticks) to render correctly on GitHub. Outside code blocks, GitHub renders them as regular Unicode text with a proportional font, causing misalignment. Inside code blocks, monospace font is guaranteed. This constraint applies to the hero banner, section dividers, architecture diagrams, and project structure tree.
+
+The phase maps to 13 requirements (README-01 through README-13). All content can be derived from existing project files with no external research needed. The planner must ensure each requirement maps to a distinct task and that the correct source files are referenced for each section.
+
+**Primary recommendation:** Write all ASCII art elements (banner, section headers, diagrams, tree) inside fenced code blocks. Derive all content from existing project files. Use ui-brand.md as the visual authority for symbol choices.
+
+---
+
+## Standard Stack
+
+This phase has no software library dependencies. The "stack" is the set of source files the README author must read.
+
+### Content Sources (complete inventory)
+
+| Source File | Used For |
+|-------------|---------|
+| `.claude/commands/vit/*.md` (31 files) | Commands reference (README-05) |
+| `.claude/agents/vit-*.md` (16 files) | Agents reference (README-06) |
+| `.claude/vit/references/ui-brand.md` | Visual style authority (README-01, README-12) |
+| `.claude/vit/references/planning-config.md` | Config keys reference (README-07) |
+| `.claude/vit/references/model-profiles.md` | Model profile matrix table (README-07) |
+| `.github/workflows/phase-ci.yml` | CI integration section (README-08) |
+| `.planning/REQUIREMENTS.md` | Project requirements context |
+| `.planning/ROADMAP.md` | Architecture + project context |
+| `.planning/PROJECT.md` | Project overview, decisions |
+| `.planning/codebase/STRUCTURE.md` | Directory tree (README-10) |
+| Existing `README.md` | Baseline to replace |
+
+### No External Libraries Required
+
+This phase installs nothing. No `npm install`. The output is a single Markdown file.
+
+---
+
+## Architecture Patterns
+
+### README Section Order
+
+The 13 requirements map to a logical reading order:
+
+```
+1. Hero banner (README-01)              — visual hook, first impression
+2. What is VIT? + core loop (README-02) — orient the reader
+3. Install section (README-03)          — get them started fast
+4. Quick Start walkthrough (README-04)  — first success path
+5. Commands reference (README-05)       — 31 commands, 11 groups
+6. Agents reference (README-06)         — 16 agents table
+7. Settings reference (README-07)       — config.json keys + model matrix
+8. GitHub CI Integration (README-08)    — phase-ci.yml explanation
+9. Architecture diagram (README-09)     — ASCII agent pipeline diagram
+10. Project structure (README-10)       — .planning/ + .claude/ tree
+11. Common Workflows (README-11)        — 6 recipes
+12. [Style is cross-cutting] (README-12)
+13. Footer (README-13)
+```
+
+### ASCII Art Rendering Rule (CRITICAL)
+
+**Finding:** GitHub renders Markdown with a proportional font by default. Box-drawing characters (━, ─, ╔, ║, ╗, ╚, ╝, ╠, ╣, ◆, etc.) only align correctly when wrapped in a fenced code block.
+
+**Rule:** Every multi-character ASCII art element goes in a fenced code block:
+
+```
+\`\`\`
+╔══════════════════════════════════════════════════════════════╗
+║  VIT ► PLANNING                                              ║
+╚══════════════════════════════════════════════════════════════╝
+\`\`\`
+```
+
+**Exception:** Single Unicode status symbols inline in prose are fine (e.g., "✓ Complete", "◆ In Progress") because they're single characters, not alignment-dependent multi-character constructions.
+
+**Source:** GitHub issue `github/markup#334`, `isaacs/github#1164` — both confirm font substitution breaks alignment outside code blocks.
+
+### The 11 Command Groups
+
+The requirements specify 31 commands in 11 groups. Current groupings (verified against actual command files):
+
+| # | Group Name | Commands |
+|---|-----------|---------|
+| 1 | Project Init | `new-project`, `new-milestone`, `map-codebase` |
+| 2 | Planning | `plan-phase`, `discuss-phase`, `research-phase`, `list-phase-assumptions` |
+| 3 | Execution | `execute-phase`, `quick` |
+| 4 | Verification | `verify-work`, `audit-milestone` |
+| 5 | Progress | `progress`, `list-milestones` |
+| 6 | Roadmap | `add-phase`, `insert-phase`, `remove-phase`, `plan-milestone-gaps` |
+| 7 | Session | `pause-work`, `resume-work` |
+| 8 | Team | `assign-phase`, `team-status` |
+| 9 | Maintenance | `complete-milestone`, `review-feedback`, `debug` |
+| 10 | Config | `settings`, `set-profile`, `update` |
+| 11 | Meta | `help`, `join-discord`, `add-todo`, `check-todos` |
+
+**Count check:** 3+4+2+2+2+4+2+2+3+3+4 = 31. Confirmed.
+
+**Note:** The old STRUCTURE.md (dated 2026-03-18) listed 29 commands in 10 groups and merged "Meta" and "Progress" differently. The correct current state is 31 commands. `assign-phase` and `team-status` are the two additions — they belong in a new "Team" group (group 8 above).
+
+### Command Entry Format
+
+Each command entry in README-05 needs: name, description, usage example, produced artifacts. Derive from command `.md` files using the `description:` frontmatter field and the command's `<objective>` section.
+
+### Agent Table Format
+
+README-06 requires a table with: agent name, spawner command, role description, output artifact. All 16 agents have `description:` frontmatter. Spawner information is in the description field itself (e.g., "Spawned by /vit:plan-phase").
+
+### config.json Keys (README-07)
+
+Verified against `planning-config.md` and the live `config.json`:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `mode` | `"yolo"` | Execution mode (yolo = no confirmations) |
+| `depth` | `"standard"` | Planning depth |
+| `parallelization` | `true` | Enable parallel agent spawning |
+| `commit_docs` | `true` | Commit planning artifacts to git |
+| `model_profile` | `"balanced"` | Agent model selection profile |
+| `workflow.research` | `true` | Enable research step in plan-phase |
+| `workflow.plan_check` | `true` | Enable plan checker before execution |
+| `workflow.verifier` | `true` | Enable verifier after execution |
+| `team.enabled` | `false` | Enable team mode |
+| `team.roster` | `[]` | Array of `{handle, role}` engineer objects |
+| `team.default_reviewer` | `""` | GitHub handle for PR reviewer auto-assignment |
+
+**Model profile matrix** — from `model-profiles.md` (11 agents mapped across quality/balanced/budget).
+
+### Architecture Diagram Content (README-09)
+
+The diagram must show three command pipelines with their spawned agents. Based on existing README + ROADMAP.md:
+
+```
+/vit:plan-phase
+    ├── vit-phase-researcher  → RESEARCH.md
+    ├── vit-planner           → PLAN.md
+    └── vit-plan-checker      → verification
+
+/vit:execute-phase
+    ├── Draft PR (gh pr create --draft)
+    ├── Wave N: vit-executor(s) → atomic commits
+    ├── vit-integration-checker
+    ├── vit-test-writer        → tests/phases/
+    ├── vit-doc-updater        → README/CHANGELOG
+    └── git push → phase-ci.yml → GitHub issue comment
+
+/vit:verify-work
+    ├── vit-verifier           → VERIFICATION.md
+    ├── gh pr ready (Route A)
+    └── vit-pr-reviewer        → GitHub review comments
+```
+
+State files: `.planning/STATE.md`, `.planning/MILESTONE.md`, per-phase `PLAN.md`
+
+### Project Structure Tree (README-10)
+
+Two trees needed: `.planning/` and `.claude/`. Source: `STRUCTURE.md`. Must be in code block.
+
+### Common Workflows (README-11) — 6 Recipes
+
+Requirements specify exactly 6 recipes:
+1. Greenfield — start a new project from scratch
+2. Brownfield — adopt VIT on an existing project
+3. Resume — pick up after a context reset
+4. Urgent work — insert a hotfix/urgent phase
+5. Team collaboration — team mode setup and handoffs
+6. Debugging — use /vit:debug for systematic issue investigation
+
+### Footer (README-13)
+
+Must include: MIT license, Discord link, GitHub issues link, docs site link. Discord and docs site URLs need to be verified or left as placeholders.
+
+---
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Command descriptions | Manually write from memory | Read `description:` frontmatter from each `.md` file | Frontmatter is authoritative; memory is stale |
+| Agent spawner info | Manually write | Parse agent `description:` fields (they include "Spawned by X") | Already documented there |
+| config.json schema | Guess from config.json alone | Cross-reference with `planning-config.md` | planning-config.md has descriptions, not just keys |
+| Model profile table | Recreate from memory | Copy directly from `model-profiles.md` | Has all 11 agents and 3 profiles, already correct |
+| Directory tree | Write from memory | Read `STRUCTURE.md` | Already has verified tree |
+
+**Key insight:** All content for this README already exists in the repository. The executor's job is accurate transcription and organization, not invention.
+
+---
+
+## Common Pitfalls
+
+### Pitfall 1: ASCII Art Outside Code Blocks
+
+**What goes wrong:** Box-drawing characters (━, ─, ╔, ║) misalign on GitHub because the font is proportional.
+**Why it happens:** GitHub renders Markdown with a proportional font; only `<code>` elements use monospace.
+**How to avoid:** Every multi-line ASCII art construction goes in a fenced code block.
+**Warning signs:** If you're writing `━━━━━━━━━━━━━━` directly in a Markdown heading line, that's wrong.
+
+### Pitfall 2: Wrong Command Count
+
+**What goes wrong:** Documentation says "29 commands" (old count) instead of 31.
+**Why it happens:** STRUCTURE.md was written at v1.0 when there were 29 commands. Two were added (assign-phase, team-status).
+**How to avoid:** Count the actual files in `.claude/commands/vit/` before writing. Current count: 31.
+**Warning signs:** If your group breakdown sums to anything other than 31, recount.
+
+### Pitfall 3: Using Unapproved Emoji
+
+**What goes wrong:** Random emoji (🚀, ✨, 💡) appear in the README, violating README-12.
+**Why it happens:** LLM tendency to add visual flair.
+**How to avoid:** Approved symbols only per ui-brand.md: ✓ ✗ ◆ ○ ⚡ ⚠ 🎉 (milestone complete banner only).
+**Warning signs:** Any emoji not in that list is a violation.
+
+### Pitfall 4: Banner Width Inconsistency
+
+**What goes wrong:** Section headers and checkpoint boxes have different widths.
+**Why it happens:** ui-brand.md specifies 62-character checkpoint boxes; stage banners use 53 characters. Mixing them breaks visual consistency.
+**How to avoid:** Stage banners: `━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━` (53 `━`). Checkpoint boxes: 62 chars wide with `╔══` borders. For README section headers, the style is `━━━` divider lines (length consistent within the document).
+**Warning signs:** Counting the characters in each banner and finding different lengths.
+
+### Pitfall 5: Incomplete Commands Reference
+
+**What goes wrong:** Some commands missing from README-05 because the author used memory instead of reading all 31 files.
+**Why it happens:** It's easy to forget `list-phase-assumptions`, `assign-phase`, `team-status`, or `plan-milestone-gaps`.
+**How to avoid:** Enumerate all 31 files from the directory, don't write from memory.
+**Warning signs:** Group counts don't sum to 31.
+
+### Pitfall 6: Missing "Produced Artifacts" Column
+
+**What goes wrong:** Commands reference only has name + description, missing usage example and produced artifacts per README-05.
+**Why it happens:** Simpler table format temptation.
+**How to avoid:** Each command entry must have 4 data points: name, description, usage example, produced artifacts.
+**Warning signs:** The table only has 2 columns.
+
+---
+
+## Code Examples
+
+### Section Header Pattern (ui-brand.md)
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ VIT ► {STAGE NAME}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Source: `.claude/vit/references/ui-brand.md` — Stage Banners section
+
+### Checkpoint Box Pattern (ui-brand.md)
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  CHECKPOINT: {Type}                                          ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+Source: `.claude/vit/references/ui-brand.md` — Checkpoint Boxes section (62 chars wide)
+
+### Divider Pattern (ui-brand.md)
+
+```
+───────────────────────────────────────────────────────────────
+```
+
+Source: `.claude/vit/references/ui-brand.md` — Next Up Block section
+
+### Core Loop Diagram (from existing README)
+
+```
+/vit:new-project  →  /vit:plan-phase  →  /vit:execute-phase  →  /vit:verify-work
+```
+
+Source: Existing `README.md` lines 19-23 — this is the canonical representation
+
+---
+
+## State of the Art
+
+| Old Approach | Current Approach | Impact |
+|---|---|---|
+| 29 commands in README | 31 commands (added assign-phase, team-status) | Must add "Team" group (11th group) |
+| Agents listed in simple role table | Full table with spawner + output artifact | Richer reference |
+| No ASCII art / visual branding | ASCII art hero + section headers | README-12 requirement |
+| Minimal install section | Visual install with component listing | README-03 requirement |
+
+**Note:** The existing README.md is a functional but minimal reference. This phase replaces it wholesale.
+
+---
+
+## Open Questions
+
+1. **Footer URLs for Discord and docs site**
+   - What we know: README-13 requires Discord link and docs site link
+   - What's unclear: The actual URLs. The docs site doesn't exist yet (Phase 02). Discord URL not found in project files.
+   - Recommendation: Use placeholder text like `[Discord](https://discord.gg/vit-claude)` and `[Docs](https://vit-claude.dev)` with a note, or leave as `TBD` anchors. The planner should flag this for the executor to verify with the maintainer.
+
+2. **Hero banner ASCII art content**
+   - What we know: Must use box-drawing characters consistent with ui-brand.md, render correctly on GitHub and terminal (README-01)
+   - What's unclear: The specific text/art of the banner — no existing banner exists. Design is at executor discretion.
+   - Recommendation: Executor creates a banner using the VIT name, the `VIT ►` prefix style, and `━`/`╔`/`║` characters, wrapped in a fenced code block. Width should be consistent with ui-brand.md (53-char stage banner width or 62-char checkpoint box width — pick one and stay consistent).
+
+3. **"Produced artifacts" for every command**
+   - What we know: README-05 requires "produced artifacts" per command
+   - What's unclear: Some commands produce no files (e.g., `join-discord`, `help`) — "produced artifacts" is N/A
+   - Recommendation: Use "None" or "—" for commands that produce no artifacts. Use the actual file names for ones that do (e.g., plan-phase → `PLAN.md`, execute-phase → commits + `SUMMARY.md`).
+
+---
+
+## Sources
+
+### Primary (HIGH confidence)
+- `.claude/vit/references/ui-brand.md` — visual patterns, approved symbols, banner formats
+- `.claude/vit/references/planning-config.md` — config.json schema and all keys
+- `.claude/vit/references/model-profiles.md` — complete model profile matrix
+- `.claude/commands/vit/*.md` (31 files) — command descriptions and behaviors
+- `.claude/agents/vit-*.md` (16 files) — agent descriptions and spawner info
+- `.github/workflows/phase-ci.yml` — CI workflow behavior
+- `.planning/codebase/STRUCTURE.md` — directory tree
+
+### Secondary (MEDIUM confidence)
+- GitHub issue `github/markup#334` + `isaacs/github#1164` — ASCII art must be in code blocks for correct rendering on GitHub (WebSearch verified with official GitHub issue tracker)
+
+### Tertiary (LOW confidence)
+- Proposed Discord URL and docs site URL — not found in any project file; flagged as open questions
+
+---
+
+## Metadata
+
+**Confidence breakdown:**
+- Content inventory: HIGH — all 31 commands and 16 agents verified by directory listing
+- Visual style rules: HIGH — sourced directly from ui-brand.md
+- ASCII rendering constraint: MEDIUM — verified via GitHub issue tracker, well-established community knowledge
+- Command groupings (11 groups): HIGH — derived by adding "Team" group to existing 10-group categorization; count verified at 31
+- Footer URLs: LOW — not found in project files
+
+**Research date:** 2026-03-19
+**Valid until:** 2026-04-19 (static project, no fast-moving dependencies)

--- a/.planning/phases/v1.1/01-readme-rewrite/01-VERIFICATION.md
+++ b/.planning/phases/v1.1/01-readme-rewrite/01-VERIFICATION.md
@@ -1,0 +1,84 @@
+---
+phase: 01-readme-rewrite
+verified: 2026-03-19T00:00:00Z
+status: passed
+score: 5/5 must-haves verified
+---
+
+# Phase 01: README Rewrite Verification Report
+
+**Phase Goal:** Users and contributors encounter a complete, visually consistent README that documents every command, agent, and config key in the project.
+**Verified:** 2026-03-19
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| #   | Truth                                                                                    | Status     | Evidence                                                                                              |
+| --- | ---------------------------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------- |
+| 1   | ASCII art hero banner renders correctly on GitHub and in terminal without layout breaks   | ✓ VERIFIED | `README.md` line 1: ` ```diff` block with ANSI Shadow 6-line VIT art, `+` prefixes on art lines, subtitle lines without prefix — correct GitHub diff rendering technique |
+| 2   | All 31 commands documented with name, description, usage, artifacts in 11 groups         | ✓ VERIFIED | Exact count: 31 `| \`/vit:...\`` table rows, all with 4 columns; 11 `###` group headings confirmed (Project Init, Planning, Execution, Verification, Progress, Roadmap, Session, Team, Maintenance, Config, Meta); each group has `───` ASCII divider inside a fenced code block |
+| 3   | All 16 agents documented in table with spawner, role, output                             | ✓ VERIFIED | Exact count: 16 agent rows in table (filtering out model profile matrix); all rows have 4 columns (Agent, Spawned By, Role, Output); all 16 match actual `files/agents/vit-*.md` files 1:1 |
+| 4   | All config.json keys documented with defaults, descriptions, and model profile matrix     | ✓ VERIFIED | 11 config keys in table with Key/Default/Description columns (`mode`, `depth`, `parallelization`, `commit_docs`, `model_profile`, `workflow.research`, `workflow.plan_check`, `workflow.verifier`, `team.enabled`, `team.roster`, `team.default_reviewer`); sample JSON block present; model profile matrix with 11 agents × 3 profiles present |
+| 5   | Visual style consistent: ━━━ for section headers, ─── for dividers, no unapproved emoji  | ✓ VERIFIED | All 16 `━━━` banner lines are inside fenced code blocks (programmatically verified); all 65 `─── ` divider lines are inside fenced code blocks; zero emoji outside fenced code blocks; all `━━━` banners are exactly 53 chars wide; all `───` dividers are exactly 43 chars wide |
+
+**Score:** 5/5 truths verified
+
+### Required Artifacts
+
+| Artifact    | Expected                                    | Status      | Details                                       |
+| ----------- | ------------------------------------------- | ----------- | --------------------------------------------- |
+| `README.md` | Complete README with all reference sections | ✓ VERIFIED  | 617 lines; hero banner, commands reference (31 commands / 11 groups), agents reference (16 agents), settings reference (11 keys + model matrix), GitHub CI, architecture, project structure, common workflows, update, license sections present |
+
+### Key Link Verification
+
+| From                    | To                           | Via                          | Status      | Details                                                               |
+| ----------------------- | ---------------------------- | ---------------------------- | ----------- | --------------------------------------------------------------------- |
+| README commands table   | `files/commands/vit/` files  | Command name matching        | ✓ WIRED     | 31/31 README command names match actual `*.md` files — no orphans, no gaps |
+| README agents table     | `files/agents/` files        | Agent name matching          | ✓ WIRED     | 16/16 README agent names match actual `vit-*.md` files — no orphans, no gaps |
+| Model profile matrix    | Agents reference table       | Agent name overlap           | ✓ WIRED     | 11 agents in matrix are subset of 16 in agents table — consistent naming |
+
+### Anti-Patterns Found
+
+| File        | Line      | Pattern                           | Severity | Impact |
+| ----------- | --------- | --------------------------------- | -------- | ------ |
+| `README.md` | 390–409   | Emoji (✅ ❌ 🔄) present          | Info     | Emoji are inside fenced code blocks representing literal GitHub CI comment output — intentional and documented in Plan 04 decisions as acceptable |
+
+No blockers or warnings found.
+
+### Human Verification Required
+
+#### 1. Hero Banner Visual Render on GitHub
+
+**Test:** Open `README.md` on the GitHub branch page in a browser.
+**Expected:** The "VIT" ANSI Shadow art at the top renders in green (via diff syntax highlighting) with the subtitle text in neutral color below it. No broken characters or layout shifts.
+**Why human:** Cannot confirm actual GitHub diff syntax highlighting color rendering programmatically. The code structure is verified correct but the visual output requires a browser.
+
+#### 2. Section Banner and Group Divider Visual Alignment
+
+**Test:** On the same GitHub page, scroll through all 11 command groups and 8 major sections.
+**Expected:** Every `VIT ► SECTION NAME` banner shows with flanking `━━━` lines in a monospace code block. Every group name shows with flanking `───` lines. All appear visually uniform.
+**Why human:** Width consistency is verified (53 chars for banners, 43 for dividers) but visual proportionality on the GitHub rendered page requires a human eye.
+
+## Summary
+
+Phase 01 (README Rewrite) achieves its goal. The README.md is complete, accurate, and consistently styled.
+
+**What was verified against the actual codebase (not SUMMARY claims):**
+
+- All 31 slash commands are documented — confirmed by counting table rows AND cross-referencing against actual `files/commands/vit/` filenames. Zero mismatches.
+- All 16 agents are documented — confirmed by counting table rows AND cross-referencing against actual `files/agents/` filenames. Zero mismatches.
+- All 11 config.json keys are documented with defaults and descriptions, plus the model profile matrix with all 3 profiles.
+- The hero banner uses a `diff` fenced code block with `+` prefixes on art lines — the correct technique for GitHub green rendering.
+- Visual style rules are upheld: all `━━━` and `───` characters are inside fenced code blocks (programmatically verified by tracking code block state), no emoji appear in prose.
+- 11 command groups present with correct names.
+- No placeholder markers or TODO comments remain.
+
+Two human verification items remain (visual render on GitHub) but do not block goal achievement — the underlying structure is correct.
+
+---
+
+_Verified: 2026-03-19_
+_Verifier: Claude (vit-verifier)_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Phase 01 (readme-rewrite): Complete README.md rewrite with ANSI Shadow ASCII art hero banner (diff-block green rendering), 31-command reference in 11 groups, 16-agent table, 11-key settings reference with model profile matrix, and consistent 53-char section banners — replacing the previous 201-line minimal doc with a fully structured branded document
+
 ## [1.0] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,7 +94,157 @@ A verifier agent runs goal-backward analysis and produces `VERIFICATION.md`. If 
 
 31 commands organized into 11 groups. Each command is a slash command invoked as `/vit:<name>`.
 
-<!-- COMMANDS_PLACEHOLDER -->
+### Project Init
+
+```
+───────────────────────────────────────────
+ PROJECT INIT
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:new-project` | Initialize a new project with deep context gathering and PROJECT.md | `/vit:new-project` | `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, `STATE.md`, `config.json` |
+| `/vit:new-milestone` | Start a new milestone cycle — update PROJECT.md and route to requirements | `/vit:new-milestone v1.1 Notifications` | `PROJECT.md`, `ROADMAP.md`, `REQUIREMENTS.md`, `STATE.md` |
+| `/vit:map-codebase` | Analyze codebase with parallel mapper agents to produce .planning/codebase/ documents | `/vit:map-codebase` | `.planning/codebase/` (7 documents) |
+
+### Planning
+
+```
+───────────────────────────────────────────
+ PLANNING
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:plan-phase` | Create detailed execution plan for a phase (PLAN.md) with verification loop | `/vit:plan-phase 3` | `{phase}-PLAN.md` files, `{phase}-RESEARCH.md` |
+| `/vit:discuss-phase` | Gather phase context through adaptive questioning before planning | `/vit:discuss-phase 3` | `{phase}-CONTEXT.md` |
+| `/vit:research-phase` | Research how to implement a phase (standalone — usually use /vit:plan-phase instead) | `/vit:research-phase 3` | `{phase}-RESEARCH.md` |
+| `/vit:list-phase-assumptions` | Surface Claude's assumptions about a phase approach before planning | `/vit:list-phase-assumptions 3` | None |
+
+### Execution
+
+```
+───────────────────────────────────────────
+ EXECUTION
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:execute-phase` | Execute all plans in a phase with wave-based parallelization | `/vit:execute-phase 3` | Committed code, `{plan}-SUMMARY.md` files, updated `STATE.md` |
+| `/vit:quick` | Execute a quick task with VIT guarantees (atomic commits, state tracking) but skip optional agents | `/vit:quick` | Committed code, `STATE.md` update |
+
+### Verification
+
+```
+───────────────────────────────────────────
+ VERIFICATION
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:verify-work` | Validate built features through conversational UAT | `/vit:verify-work 3` | `{phase}-UAT.md` |
+| `/vit:audit-milestone` | Audit milestone completion against original intent before archiving | `/vit:audit-milestone v1.0` | `{version}-MILESTONE-AUDIT.md` |
+
+### Progress
+
+```
+───────────────────────────────────────────
+ PROGRESS
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:progress` | Check project progress, show context, and route to next action (execute or plan) | `/vit:progress` | None |
+| `/vit:list-milestones` | Show all active milestone worktrees and their current state | `/vit:list-milestones` | None |
+
+### Roadmap
+
+```
+───────────────────────────────────────────
+ ROADMAP
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:add-phase` | Add phase to end of current milestone in roadmap | `/vit:add-phase Add authentication` | Updated `ROADMAP.md` |
+| `/vit:insert-phase` | Insert urgent work as decimal phase (e.g., 72.1) between existing phases | `/vit:insert-phase 3 Fix critical bug` | Updated `ROADMAP.md` |
+| `/vit:remove-phase` | Remove a future phase from roadmap and renumber subsequent phases | `/vit:remove-phase 5` | Updated `ROADMAP.md` |
+| `/vit:plan-milestone-gaps` | Create phases to close all gaps identified by milestone audit | `/vit:plan-milestone-gaps` | Updated `ROADMAP.md`, new `PLAN.md` files |
+
+### Session
+
+```
+───────────────────────────────────────────
+ SESSION
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:pause-work` | Create context handoff when pausing work mid-phase | `/vit:pause-work` | `.continue-here.md` |
+| `/vit:resume-work` | Resume work from previous session with full context restoration | `/vit:resume-work` | None |
+
+### Team
+
+```
+───────────────────────────────────────────
+ TEAM
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:assign-phase` | Assign a phase or individual plan to an engineer | `/vit:assign-phase 3 @alice` | Updated `PLAN.md` files, updated `STATE.md` |
+| `/vit:team-status` | Show team assignment status — who's working on what, what's blocked, what's unassigned | `/vit:team-status` | None |
+
+### Maintenance
+
+```
+───────────────────────────────────────────
+ MAINTENANCE
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:complete-milestone` | Archive completed milestone and prepare for next version | `/vit:complete-milestone v1.0` | `milestones/v1.0/` archive, git tag |
+| `/vit:review-feedback` | Read developer feedback on a GitHub feature issue and implement requested changes | `/vit:review-feedback 3` | Atomic commits per change |
+| `/vit:debug` | Systematic debugging with persistent state across context resets | `/vit:debug login fails on mobile` | `.planning/debug/{issue}.md` |
+
+### Config
+
+```
+───────────────────────────────────────────
+ CONFIG
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:settings` | Configure VIT workflow toggles and model profile | `/vit:settings` | Updated `config.json` |
+| `/vit:set-profile` | Switch model profile for VIT agents (quality/balanced/budget) | `/vit:set-profile balanced` | Updated `config.json` |
+| `/vit:update` | Update VIT to latest version with changelog display | `/vit:update` | Updated `.claude/vit/` files |
+
+### Meta
+
+```
+───────────────────────────────────────────
+ META
+───────────────────────────────────────────
+```
+
+| Command | Description | Usage | Produces |
+|---------|-------------|-------|----------|
+| `/vit:help` | Show available VIT commands and usage guide | `/vit:help` | None |
+| `/vit:join-discord` | Join the VIT Discord community | `/vit:join-discord` | None |
+| `/vit:add-todo` | Capture idea or task as todo from current conversation context | `/vit:add-todo refactor auth module` | `.planning/todos/pending/{todo}.md` |
+| `/vit:check-todos` | List pending todos and select one to work on | `/vit:check-todos` | None |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,81 @@ VIT spawns 16 specialist agents automatically — you don't invoke them directly
 
 VIT is configured through `.planning/config.json` in your project root. All settings are optional — defaults work out of the box.
 
-<!-- SETTINGS_PLACEHOLDER -->
+### config.json Keys
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `mode` | `"yolo"` | Execution mode: `yolo` = no confirmations, `interactive` = confirm each step |
+| `depth` | `"standard"` | Planning depth: `quick`, `standard`, or `comprehensive` |
+| `parallelization` | `true` | Enable parallel agent spawning in execute-phase |
+| `commit_docs` | `true` | Commit `.planning/` artifacts to git |
+| `model_profile` | `"balanced"` | Agent model selection profile: `quality`, `balanced`, or `budget` |
+| `workflow.research` | `true` | Enable research step in plan-phase |
+| `workflow.plan_check` | `true` | Enable plan checker before execution |
+| `workflow.verifier` | `true` | Enable verifier after execution |
+| `team.enabled` | `false` | Enable team mode for multi-engineer collaboration |
+| `team.roster` | `[]` | Array of `{"handle": "alice", "role": "backend"}` engineer objects |
+| `team.default_reviewer` | `""` | GitHub handle for auto-assigning PR reviewer |
+
+**Sample config.json with all defaults:**
+
+```json
+{
+  "mode": "yolo",
+  "depth": "standard",
+  "parallelization": true,
+  "commit_docs": true,
+  "model_profile": "balanced",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true
+  },
+  "team": {
+    "enabled": false,
+    "roster": [],
+    "default_reviewer": ""
+  }
+}
+```
+
+### Model Profile Matrix
+
+Control which Claude model each agent uses to balance quality vs. token spend.
+
+| Agent | `quality` | `balanced` | `budget` |
+|-------|-----------|------------|----------|
+| `vit-planner` | opus | opus | sonnet |
+| `vit-roadmapper` | opus | sonnet | sonnet |
+| `vit-executor` | opus | sonnet | sonnet |
+| `vit-phase-researcher` | opus | sonnet | haiku |
+| `vit-project-researcher` | opus | sonnet | haiku |
+| `vit-research-synthesizer` | sonnet | sonnet | haiku |
+| `vit-debugger` | opus | sonnet | sonnet |
+| `vit-codebase-mapper` | sonnet | haiku | haiku |
+| `vit-verifier` | sonnet | sonnet | haiku |
+| `vit-plan-checker` | sonnet | sonnet | haiku |
+| `vit-integration-checker` | sonnet | sonnet | haiku |
+
+**Profile explanations:**
+
+- **quality** — Maximum reasoning: Opus for all decision-making agents. Use when quota is available and architecture quality is critical.
+- **balanced** (default) — Smart allocation: Opus only for planning where architecture decisions happen, Sonnet for execution and verification.
+- **budget** — Minimal Opus: Sonnet for code generation, Haiku for research and verification. Use when conserving quota or running high-volume work.
+
+**Switching profiles:**
+
+```bash
+/vit:set-profile quality    # or balanced, budget
+```
+
+Or edit `.planning/config.json` directly:
+
+```json
+{
+  "model_profile": "quality"
+}
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
   Atomic commits · Parallel agents · GitHub CI feedback
 ```
 
+[![GitHub stars](https://img.shields.io/github/stars/LeVarez/vit-cc?style=flat-square&logo=github)](https://github.com/LeVarez/vit-cc/stargazers)
+[![GitHub watchers](https://img.shields.io/github/watchers/LeVarez/vit-cc?style=flat-square&logo=github)](https://github.com/LeVarez/vit-cc/watchers)
+[![GitHub forks](https://img.shields.io/github/forks/LeVarez/vit-cc?style=flat-square&logo=github)](https://github.com/LeVarez/vit-cc/network/members)
+[![GitHub issues](https://img.shields.io/github/issues/LeVarez/vit-cc?style=flat-square&logo=github)](https://github.com/LeVarez/vit-cc/issues)
+[![GitHub license](https://img.shields.io/github/license/LeVarez/vit-cc?style=flat-square)](https://github.com/LeVarez/vit-cc/blob/main/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/LeVarez/vit-cc?style=flat-square&logo=github)](https://github.com/LeVarez/vit-cc/commits)
+
 Phase-based project execution framework for Claude Code — with GitHub integration.
 
 ---

--- a/README.md
+++ b/README.md
@@ -258,7 +258,24 @@ A verifier agent runs goal-backward analysis and produces `VERIFICATION.md`. If 
 
 VIT spawns 16 specialist agents automatically — you don't invoke them directly.
 
-<!-- AGENTS_PLACEHOLDER -->
+| Agent | Spawned By | Role | Output |
+|-------|------------|------|--------|
+| `vit-planner` | `/vit:plan-phase` | Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification | PLAN.md files |
+| `vit-executor` | `/vit:execute-phase` | Executes VIT plans with atomic commits, deviation handling, checkpoint protocols, and state management | Per-task commits, SUMMARY.md |
+| `vit-verifier` | `/vit:execute-phase` | Verifies phase goal achievement through goal-backward analysis — checks codebase delivers what phase promised, not just that tasks completed | VERIFICATION.md |
+| `vit-phase-researcher` | `/vit:plan-phase` | Researches how to implement a phase before planning; produces RESEARCH.md consumed by vit-planner | RESEARCH.md |
+| `vit-plan-checker` | `/vit:plan-phase` | Verifies plans will achieve phase goal before execution via goal-backward analysis of plan quality | Plan quality report |
+| `vit-project-researcher` | `/vit:new-project`, `/vit:new-milestone` | Researches domain ecosystem before roadmap creation; produces files in `.planning/research/` consumed during roadmap creation | `.planning/research/*.md` |
+| `vit-research-synthesizer` | `/vit:new-project` | Synthesizes research outputs from parallel researcher agents into a unified SUMMARY.md | `.planning/research/SUMMARY.md` |
+| `vit-roadmapper` | `/vit:new-project` | Creates project roadmaps with phase breakdown, requirement mapping, success criteria derivation, and coverage validation | ROADMAP.md |
+| `vit-codebase-mapper` | `/vit:map-codebase` | Explores codebase and writes structured analysis documents for a given focus area (tech, arch, quality, concerns) | `.planning/codebase/*.md` |
+| `vit-integration-checker` | `/vit:audit-milestone` | Verifies cross-phase integration and E2E flows — checks that phases connect properly and user workflows complete end-to-end | Integration audit report |
+| `vit-debugger` | `/vit:debug` | Investigates bugs using scientific method, manages debug sessions, handles checkpoints | Debug session file |
+| `vit-github-reviewer` | `/vit:review-feedback` | Reads GitHub issue feedback comments for a phase and implements requested changes as fix commits | Fix commits + GitHub reply |
+| `vit-test-writer` | `/vit:execute-phase` | Generates Vitest unit tests from phase plan must_haves and SUMMARY.md deliverables | Test files |
+| `vit-pr-reviewer` | `/vit:verify-work` | Reviews promoted PRs and posts severity-tiered findings as GitHub review comments | GitHub PR review comments |
+| `vit-doc-updater` | `/vit:execute-phase` | Updates targeted documentation sections after a phase completes, reading SUMMARY.md and PLAN.md to identify which docs/sections to update | Updated docs + CHANGELOG entry |
+| `vit-changelog-writer` | `/vit:complete-milestone` | Writes versioned CHANGELOG entry at milestone completion and updates all project documentation by reading all phase SUMMARY.md files | CHANGELOG.md versioned entry |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# vit-cc
-
-**Phase-based project execution framework for Claude Code — with GitHub integration.**
-
-VIT gives Claude Code a structured, repeatable way to plan and execute software projects: one phase at a time, with atomic commits, parallel agents, CI feedback on GitHub issues, and persistent state that survives context resets.
-
-```bash
-npx vit-claude
 ```
+╔══════════════════════════════════════════════════════════════╗
+║                                                              ║
+║   VIT ►  Phase-based project execution for Claude Code       ║
+║                                                              ║
+║   Plan  →  Execute  →  Verify  →  Merge                      ║
+║   Atomic commits · Parallel agents · GitHub CI feedback      ║
+║                                                              ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+Phase-based project execution framework for Claude Code — with GitHub integration.
 
 ---
 
@@ -14,36 +17,15 @@ npx vit-claude
 
 VIT is a Claude Code workflow framework. It installs as slash commands, specialist agents, and session hooks directly into your `.claude/` directory.
 
-The core loop is:
+The core loop:
 
 ```
-/vit:new-project  →  /vit:plan-phase  →  /vit:execute-phase  →  /vit:verify-work
+/vit:new-project  ->  /vit:plan-phase  ->  /vit:execute-phase  ->  /vit:verify-work
 ```
 
-Each phase produces atomic commits on a feature branch, updates a `STATE.md` tracker, and optionally posts CI results back to the linked GitHub issue. When context fills up, `/vit:pause-work` creates a handoff document so the next session resumes exactly where you left off.
+Each phase produces **atomic commits** on a feature branch, updates a `STATE.md` tracker, and optionally posts CI results back to the linked GitHub issue. **Parallel agents** handle research, planning, execution, testing, docs, and review simultaneously. When context fills up, `/vit:pause-work` creates a handoff document so the next session resumes exactly where you left off.
 
----
-
-## Built with GSD
-
-VIT was developed using [GSD (Get Shit Done)](https://github.com/LeVarez/gsd-cc), the framework that preceded it. GSD's planning and execution methodology was used to build VIT itself — including the roadmap, phase plans, and every execution wave. VIT is GSD's successor with a stronger emphasis on GitHub integration, multi-milestone state management, and verification agents.
-
----
-
-## GitHub Integration — the key extension
-
-VIT's standout feature is its closed-loop GitHub integration. When you push a feature branch, `phase-ci.yml` automatically:
-
-1. Runs your phase test suite (`tests/phases/`)
-2. Looks up the linked GitHub issue from `STATE.md`
-3. Posts a CI result comment directly to that issue:
-   - `✅ CI Passed — N/M tests passed. Ready for human review.`
-   - `❌ CI Failed — N failing tests. Fix before verify.`
-   - `🔄 No tests yet — waiting for test generation.`
-
-The `/vit:review-feedback` command reads developer feedback comments from the issue and implements changes as fix commits — creating a full review loop without leaving the terminal.
-
-**Requires:** `GITHUB_TOKEN` in your repo secrets (automatically available in GitHub Actions).
+**State survives context resets.** All decisions, progress, and phase context live in `.planning/` files — not in Claude's memory.
 
 ---
 
@@ -53,99 +35,112 @@ The `/vit:review-feedback` command reads developer feedback comments from the is
 npx vit-claude
 ```
 
-This copies all framework files into your project's `.claude/` directory and optionally adds the GitHub CI workflow. You can run it again to update.
+What gets installed:
 
-**What gets installed:**
-- `.claude/agents/vit-*.md` — 16 specialist agents
-- `.claude/commands/vit/*.md` — 29 slash commands
-- `.claude/hooks/vit-check-update.cjs` + `vit-statusline.js`
-- `.claude/vit/` — references, templates, workflows, VERSION
-- `.github/workflows/phase-ci.yml` — GitHub CI integration (opt-in)
+- 16 specialist agents (`.claude/agents/vit-*.md`)
+- 31 slash commands (`.claude/commands/vit/*.md`)
+- 2 session hooks (`vit-check-update.cjs`, `vit-statusline.js`)
+- Core references, templates, workflows (`.claude/vit/`)
+- GitHub CI workflow (`.github/workflows/phase-ci.yml`) — opt-in
 - Hook registrations in `.claude/settings.json`
 
+Run `npx vit-claude` again at any time to update. Your `.planning/` data is never touched.
+
 ---
 
-## Getting started
+## Quick Start
+
+**1. Initialize your project**
 
 ```
-/vit:new-project        — Deep context gathering, produces PROJECT.md + roadmap
-/vit:plan-phase 1       — Research + plan Phase 1, produces PLAN.md
-/vit:execute-phase 1    — Execute the plan with parallel agents + atomic commits
-/vit:verify-work 1      — Conversational UAT against phase success criteria
+/vit:new-project
 ```
 
----
+Claude gathers deep context through adaptive questioning, then produces `PROJECT.md` + a phased `ROADMAP.md`.
 
-## Commands reference
+**2. Plan a phase**
 
-| Command | Description |
-|---------|-------------|
-| `/vit:new-project` | Initialize a new project with deep context gathering and PROJECT.md |
-| `/vit:new-milestone` | Start a new milestone cycle — update PROJECT.md and route to requirements |
-| `/vit:plan-phase` | Create detailed execution plan for a phase (PLAN.md) with verification loop |
-| `/vit:execute-phase` | Execute all plans in a phase with wave-based parallelization |
-| `/vit:verify-work` | Validate built features through conversational UAT |
-| `/vit:quick` | Execute a quick task with VIT guarantees (atomic commits, state tracking) but skip optional agents |
-| `/vit:discuss-phase` | Gather phase context through adaptive questioning before planning |
-| `/vit:research-phase` | Research how to implement a phase (standalone — usually use /vit:plan-phase instead) |
-| `/vit:list-phase-assumptions` | Surface Claude's assumptions about a phase approach before planning |
-| `/vit:progress` | Check project progress, show context, and route to next action (execute or plan) |
-| `/vit:pause-work` | Create context handoff when pausing work mid-phase |
-| `/vit:resume-work` | Resume work from previous session with full context restoration |
-| `/vit:add-phase` | Add phase to end of current milestone in roadmap |
-| `/vit:insert-phase` | Insert urgent work as decimal phase (e.g., 72.1) between existing phases |
-| `/vit:remove-phase` | Remove a future phase from roadmap and renumber subsequent phases |
-| `/vit:audit-milestone` | Audit milestone completion against original intent before archiving |
-| `/vit:complete-milestone` | Archive completed milestone and prepare for next version |
-| `/vit:plan-milestone-gaps` | Create phases to close all gaps identified by milestone audit |
-| `/vit:list-milestones` | Show all active milestone worktrees and their current state |
-| `/vit:map-codebase` | Analyze codebase with parallel mapper agents to produce .planning/codebase/ documents |
-| `/vit:review-feedback` | Read developer feedback on a GitHub feature issue and implement requested changes |
-| `/vit:debug` | Systematic debugging with persistent state across context resets |
-| `/vit:add-todo` | Capture idea or task as todo from current conversation context |
-| `/vit:check-todos` | List pending todos and select one to work on |
-| `/vit:set-profile` | Switch model profile for VIT agents (quality/balanced/budget) |
-| `/vit:settings` | Configure VIT workflow toggles and model profile |
-| `/vit:update` | Update VIT to latest version with changelog display |
-| `/vit:help` | Show available VIT commands and usage guide |
-| `/vit:join-discord` | Join the VIT Discord community |
+```
+/vit:plan-phase 1
+```
+
+Spawns a researcher and planner in parallel. Produces a `PLAN.md` with task breakdown, wave assignments, and verification criteria. A plan checker validates it before you execute.
+
+**3. Execute the plan**
+
+```
+/vit:execute-phase 1
+```
+
+Spawns parallel executor agents per wave. Each task gets an atomic commit. After all waves complete: integration check, test generation, and doc update run automatically. Results push to your feature branch and CI posts to the linked GitHub issue.
+
+**4. Verify the work**
+
+```
+/vit:verify-work 1
+```
+
+A verifier agent runs goal-backward analysis and produces `VERIFICATION.md`. If all criteria pass, the draft PR is promoted to ready and a PR reviewer posts inline comments.
 
 ---
 
-## Agents reference
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ VIT ► COMMANDS REFERENCE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
 
-VIT spawns specialist agents automatically — you don't invoke them directly.
+## Commands Reference
 
-| Agent | Role |
-|-------|------|
-| `vit-planner` | Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification |
-| `vit-executor` | Executes VIT plans with atomic commits, deviation handling, checkpoint protocols, and state management |
-| `vit-verifier` | Verifies phase goal achievement through goal-backward analysis. Creates VERIFICATION.md report |
-| `vit-phase-researcher` | Researches how to implement a phase before planning. Produces RESEARCH.md consumed by vit-planner |
-| `vit-plan-checker` | Verifies plans will achieve phase goal before execution. Goal-backward analysis of plan quality |
-| `vit-project-researcher` | Researches domain ecosystem before roadmap creation. Produces files in .planning/research/ |
-| `vit-research-synthesizer` | Synthesizes research outputs from parallel researcher agents into SUMMARY.md |
-| `vit-roadmapper` | Creates project roadmaps with phase breakdown, requirement mapping, and coverage validation |
-| `vit-codebase-mapper` | Explores codebase and writes structured analysis documents |
-| `vit-integration-checker` | Verifies cross-phase integration and E2E flows |
-| `vit-debugger` | Investigates bugs using scientific method, manages debug sessions, handles checkpoints |
-| `vit-github-reviewer` | Reads GitHub issue feedback comments for a phase and implements requested changes as fix commits |
-| `vit-test-writer` | Generates Vitest unit tests from phase plan must_haves and SUMMARY.md |
-| `vit-pr-reviewer` | AI PR reviewer posting body summary + up to 5 inline diff comments with three severity tiers (block-merge, should-fix, nit); spawned by verify-work after PR promotion on Route A |
-| `vit-doc-updater` | Reads phase SUMMARY.md to autonomously update targeted README/docs sections and append to CHANGELOG.md [Unreleased]; spawned by execute-phase after phase completion commit |
-| `vit-changelog-writer` | Promotes CHANGELOG.md [Unreleased] to a versioned entry and updates milestone-wide README/docs; spawned by complete-milestone before archive |
+31 commands organized into 11 groups. Each command is a slash command invoked as `/vit:<name>`.
+
+<!-- COMMANDS_PLACEHOLDER -->
 
 ---
 
-## GitHub CI workflow
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ VIT ► AGENTS REFERENCE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
 
-`phase-ci.yml` triggers on pushes to `feature/**`, `milestone/**`, and `quick/**` branches.
+## Agents Reference
+
+VIT spawns 16 specialist agents automatically — you don't invoke them directly.
+
+<!-- AGENTS_PLACEHOLDER -->
+
+---
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ VIT ► SETTINGS REFERENCE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Settings Reference
+
+VIT is configured through `.planning/config.json` in your project root. All settings are optional — defaults work out of the box.
+
+<!-- SETTINGS_PLACEHOLDER -->
+
+---
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ VIT ► GITHUB CI INTEGRATION
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## GitHub CI Integration
+
+`phase-ci.yml` triggers automatically on every push to `feature/**`, `milestone/**`, and `quick/**` branches.
 
 **How it finds your issue:**
 
-Branch names follow the pattern `feature/v1.6-01-api-foundation` or `feature/42-my-feature`. The workflow extracts the phase number and looks up the corresponding GitHub issue number from `.planning/STATE.md`.
+Branch names follow the pattern `feature/v1.6-01-api-foundation`. The workflow extracts the milestone and phase number, then looks up the corresponding GitHub issue number from `.planning/STATE.md`. No manual linking needed.
 
-**What it posts:**
+**What it posts to the issue:**
 
 ```
 ✅ CI Passed — Phase v1.6/01 @ abc1234
@@ -155,46 +150,223 @@ All unit tests green. Ready for human review.
 Run /vit:verify-work 1 to complete manual UAT.
 ```
 
-**Test location:** `tests/phases/` — VIT's `vit-test-writer` agent generates these automatically after phase execution. If no tests exist yet, the workflow posts a "waiting" comment instead of failing.
+```
+❌ CI Failed — Phase v1.6/01 @ abc1234
+Branch: feature/v1.6-01-api-foundation
+Tests: 20/24 passed — 4 failing
+### Failing tests
+  ...
+Fix failures before running /vit:verify-work 1.
+```
+
+```
+🔄 CI — Phase v1.6/01 @ abc1234
+Branch: feature/v1.6-01-api-foundation
+Status: No phase tests yet — waiting for test generation
+Tests are created by vit-test-writer after phase execution completes.
+```
+
+**Test location:** `tests/phases/` — the `vit-test-writer` agent generates these automatically after phase execution. If no tests exist yet, the workflow posts the "waiting" comment instead of failing.
+
+**Feedback loop:** Use `/vit:review-feedback` to read developer comments posted to the issue and implement changes as fix commits — a complete review cycle without leaving the terminal.
+
+**Requires:** `GITHUB_TOKEN` in your repo secrets (automatically available in GitHub Actions — no setup needed).
 
 ---
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ VIT ► ARCHITECTURE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
 
 ## Architecture
 
 ```
 /vit:plan-phase
-    ├── vit-phase-researcher  (parallel, produces RESEARCH.md)
-    ├── vit-planner           (produces PLAN.md with task waves)
-    └── vit-plan-checker      (goal-backward verification)
+    ├── vit-phase-researcher    (parallel) → RESEARCH.md
+    ├── vit-planner                        → PLAN.md with task waves
+    └── vit-plan-checker                   → goal-backward verification
 
 /vit:execute-phase
-    ├── step 0.7: gh pr create --draft              (idempotent, milestone-targeted)
-    ├── Wave 1: [vit-executor] [vit-executor] ...  (parallel tasks)
+    ├── gh pr create --draft               (idempotent, milestone-targeted)
+    ├── Wave 1: [vit-executor] [vit-executor] ...   (parallel tasks)
     ├── Wave 2: [vit-executor] ...
-    ├── vit-integration-checker                     (cross-wave check)
-    ├── vit-test-writer                             (generates tests/phases/)
-    ├── step 10.6: vit-doc-updater                  (updates README/docs + CHANGELOG [Unreleased])
+    ├── vit-integration-checker            → cross-wave integration check
+    ├── vit-test-writer                    → tests/phases/
+    ├── vit-doc-updater                    → README/docs + CHANGELOG [Unreleased]
     └── git push → phase-ci.yml → GitHub issue comment
 
 /vit:verify-work
-    ├── vit-verifier          (goal-backward analysis → VERIFICATION.md)
-    ├── step 8.5: gh pr ready (Route A only — all pass, more phases remain)
-    └── step 8.6: vit-pr-reviewer (spawned after PR promotion, non-blocking)
+    ├── vit-verifier                       → VERIFICATION.md
+    ├── gh pr ready                        (Route A: all pass, phases remain)
+    └── vit-pr-reviewer                    → GitHub inline review comments
 ```
 
-State is stored in `.planning/STATE.md`, `.planning/MILESTONE.md`, and per-phase `PLAN.md` files. All state survives context resets and session boundaries.
+All state is stored in `.planning/STATE.md`, `.planning/MILESTONE.md`, and per-phase `PLAN.md` files. State survives context resets and session boundaries.
 
 ---
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ VIT ► PROJECT STRUCTURE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Project Structure
+
+**`.planning/` — per-project state (created by `/vit:new-project`)**
+
+```
+.planning/
+├── PROJECT.md              # Vision, scope, requirements, decisions
+├── REQUIREMENTS.md         # Categorized requirements with REQ-IDs
+├── ROADMAP.md              # Phase structure with success criteria
+├── STATE.md                # Current position and GitHub issue mapping
+├── MILESTONE.md            # Active milestone tracker
+├── config.json             # Workflow preferences
+├── codebase/               # Codebase analysis (from /vit:map-codebase)
+├── research/               # Domain research (from /vit:new-project)
+└── phases/
+    ├── 01-phase-name/
+    │   ├── 01-RESEARCH.md
+    │   ├── 01-01-PLAN.md
+    │   ├── 01-02-PLAN.md
+    │   ├── 01-01-SUMMARY.md
+    │   └── 01-02-SUMMARY.md
+    └── 02-phase-name/
+        └── ...
+```
+
+**`.claude/` — framework files (installed by `npx vit-claude`)**
+
+```
+.claude/
+├── agents/
+│   └── vit-*.md            # 16 specialist agent system prompts
+├── commands/
+│   └── vit/
+│       └── *.md            # 31 slash command definitions
+├── hooks/
+│   ├── vit-check-update.cjs  # Version check at session start
+│   └── vit-statusline.js     # Status sidebar renderer
+├── settings.json             # Hook registrations
+└── vit/
+    ├── references/           # Best practice guides and patterns
+    ├── templates/            # Document templates (PLAN, SUMMARY, STATE, ...)
+    └── workflows/            # Orchestration workflow definitions
+```
+
+---
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ VIT ► COMMON WORKFLOWS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Common Workflows
+
+### 1. Greenfield — start a new project from scratch
+
+Initialize VIT on a blank repo. Claude asks questions to understand your vision, then builds a complete roadmap.
+
+```
+/vit:new-project
+/vit:plan-phase 1
+/vit:execute-phase 1
+/vit:verify-work 1
+```
+
+Repeat plan/execute/verify for each phase. When a milestone is complete: `/vit:audit-milestone` then `/vit:complete-milestone`.
+
+---
+
+### 2. Brownfield — adopt VIT on an existing codebase
+
+Start with a codebase analysis so the planner understands what already exists before building the roadmap.
+
+```
+/vit:map-codebase
+/vit:new-project
+/vit:plan-phase 1
+```
+
+`/vit:map-codebase` produces structured analysis in `.planning/codebase/` that the planner reads automatically.
+
+---
+
+### 3. Resume — pick up after a context reset
+
+After starting a new Claude Code session, restore full context instantly.
+
+```
+/vit:resume-work
+```
+
+Reads `STATE.md`, the active phase plan, and any handoff documents. Shows exactly where you are and what to do next.
+
+---
+
+### 4. Urgent work — insert a hotfix between planned phases
+
+Need to ship something urgently without disrupting the roadmap?
+
+```
+/vit:insert-phase
+```
+
+Inserts as a decimal phase (e.g., `2.1`) between existing phases and renumbers subsequent phases automatically. After the hotfix: continue from where the roadmap left off.
+
+---
+
+### 5. Team collaboration — assign phases and track handoffs
+
+Enable team mode in `.planning/config.json`, then assign phases to engineers.
+
+```
+/vit:settings
+/vit:assign-phase 3
+/vit:team-status
+```
+
+`/vit:assign-phase` records the assignee in STATE.md. `/vit:team-status` shows all phases, assignees, and current progress across the milestone.
+
+---
+
+### 6. Debugging — systematic investigation with persistent state
+
+Use the structured debugging workflow for tricky bugs that need investigation across multiple sessions.
+
+```
+/vit:debug
+```
+
+Spawns `vit-debugger`, which applies a scientific method approach: hypothesis, reproduction, isolation, fix. Debug state persists across context resets so you can pick up mid-investigation.
+
+---
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ VIT ► UPDATE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
 
 ## Update
 
 ```bash
-npx vit-claude          # Re-run to update (overwrites framework files, preserves your .planning/ data)
+npx vit-claude      # Re-run to update (overwrites framework files, preserves your .planning/ data)
 /vit:update         # Or use the in-session command
 ```
 
+VIT checks for updates automatically at session start via the `vit-check-update` hook.
+
 ---
 
-## License
+## License & Community
 
-MIT
+MIT License
+
+- [GitHub Issues](https://github.com/LeVarez/vit-cc/issues) — bug reports, feature requests
+- [Discord](https://discord.gg/vit-claude) — community, help, announcements
+- [Docs](https://vit-claude.dev) — full documentation site

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-```
-╔══════════════════════════════════════════════════════════════╗
-║                                                              ║
-║   VIT ►  Phase-based project execution for Claude Code       ║
-║                                                              ║
-║   Plan  →  Execute  →  Verify  →  Merge                      ║
-║   Atomic commits · Parallel agents · GitHub CI feedback      ║
-║                                                              ║
-╚══════════════════════════════════════════════════════════════╝
+```diff
++██╗   ██╗██╗████████╗
++██║   ██║██║╚══██╔══╝
++██║   ██║██║   ██║
++╚██╗ ██╔╝██║   ██║
++ ╚████╔╝ ██║   ██║
++  ╚═══╝  ╚═╝   ╚═╝
+
+  Phase-based project execution for Claude Code
+
+  Plan  >  Execute  >  Verify  >  Merge
+  Atomic commits · Parallel agents · GitHub CI feedback
 ```
 
 Phase-based project execution framework for Claude Code — with GitHub integration.


### PR DESCRIPTION
## Goal
Users and contributors encounter a complete, visually consistent README that documents every command, agent, and config key in the project.

## Plans
- [x] 01-01: README skeleton with hero banner, intro sections, and placeholders
- [x] 01-02: Commands reference (31 commands in 11 groups)
- [x] 01-03: Agents reference (16 agents) and Settings reference (config keys + model matrix)
- [x] 01-04: Style consistency pass and visual verification

## Success Criteria
1. The ASCII art hero banner renders correctly on GitHub and in a terminal without layout breaks
2. All 31 commands are documented with name, description, usage example, and produced artifacts, organized into 11 groups with ASCII section headers
3. All 16 agents are documented in a table with spawner command, role description, and output
4. All config.json keys are documented with defaults, descriptions, and the model profile matrix table
5. Visual style is consistent throughout: section headers use ━━━, dividers use ───, no unapproved emoji, matching ui-brand.md conventions

## Links
Feature issue: #47
Closes #47